### PR TITLE
Remove hardcoded TZ

### DIFF
--- a/OpeningTimes.js
+++ b/OpeningTimes.js
@@ -5,8 +5,9 @@ const moment = require('moment');
 require('moment-timezone');
 
 class OpeningTimes {
-  constructor(openingTimes) {
+  constructor(openingTimes, timeZone) {
     this.openingTimes = openingTimes;
+    this.timeZone = timeZone;
   }
 
   getDayName(date) {
@@ -14,7 +15,7 @@ class OpeningTimes {
   }
 
   getTime(date, hour, minute) {
-    const returnDate = date.clone().tz('Europe/London');
+    const returnDate = date.clone().tz(this.timeZone);
     returnDate.set({
       hour,
       minute,
@@ -34,7 +35,7 @@ class OpeningTimes {
 
   createDateTime(dateTime, timeString) {
     const time = this.getTimeFromString(timeString);
-    return this.getTime(dateTime, time.hours, time.minutes).tz('Europe/London');
+    return this.getTime(dateTime, time.hours, time.minutes).tz(this.timeZone);
   }
 
   timeInRange(date, open, close) {

--- a/test/OpeningTimes.js
+++ b/test/OpeningTimes.js
@@ -8,11 +8,11 @@ const DaysOfTheWeek =
   ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
 
 const expect = chai.expect;
-const aMonday = moment('2016-07-25T00:00:00+01:00');
+const aMonday = moment('2016-07-25T00:00:00+00:00');
 
-function getMoment(day, hours, minutes) {
+function getMoment(day, hours, minutes, timeZone) {
   const dayNumber = DaysOfTheWeek.indexOf(day);
-  const date = moment(aMonday).tz('Europe/London');
+  const date = moment(aMonday).tz(timeZone);
   date.add(dayNumber, 'days').hours(hours).minutes(minutes);
   return date;
 }
@@ -27,31 +27,44 @@ describe('OpeningTimes', () => {
     saturday: { times: ['Closed'] },
     sunday: { times: ['Closed'] },
   };
-  const openingTimes = new OpeningTimes(syndicationOpeningTimes);
+  const openingTimes = new OpeningTimes(syndicationOpeningTimes, 'Europe/London');
   describe('isOpen()', () => {
     it('should return true if time is inside opening times', () => {
-      const date = getMoment('monday', 11, 30);
+      const date = getMoment('monday', 11, 30, 'Europe/London');
       expect(openingTimes.isOpen(date)).to.equal(true);
     });
     it('should return false if time is outside opening times', () => {
-      const date = getMoment('monday', 18, 30);
+      const date = getMoment('monday', 18, 30, 'Europe/London');
       expect(openingTimes.isOpen(date)).to.equal(false);
     });
-    describe('when passed a datetime in time zone other than Europe/London', () => {
-      it('should return true if UTC time is inside opening times', () => {
-        const date = moment('2016-07-25T08:00:00+00:00');
-        expect(openingTimes.isOpen(date)).to.equal(true);
+    describe('with opening times in different time zones', () => {
+      describe('Opening times - London 9:00 - 17:30', () => {
+        it('should return true for 8 am UTC time', () => {
+          const date = getMoment('monday', 8, 0, 'UTC');
+          expect(openingTimes.isOpen(date)).to.equal(true);
+        });
+      });
+      describe('Opening times - Tokyo 9:00 - 17:30', () => {
+        const tokyoOpeningTimes = new OpeningTimes(syndicationOpeningTimes, 'Asia/Tokyo');
+        it('should return true for 8 am London time', () => {
+          const date = getMoment('monday', 8, 0, 'Europe/London');
+          expect(tokyoOpeningTimes.isOpen(date)).to.equal(true);
+        });
+        it('should return false for 4 pm London time ', () => {
+          const date = getMoment('monday', 11, 0, 'Europe/London');
+          expect(tokyoOpeningTimes.isOpen(date)).to.equal(false);
+        });
       });
     });
   });
   describe('nextOpen()', () => {
     it('when after days closing time should return following opening time', () => {
-      const date = getMoment('monday', 18, 30);
-      const expectedOpeningDateTime = getMoment('tuesday', 9, 0);
+      const date = getMoment('monday', 18, 30, 'Europe/London');
+      const expectedOpeningDateTime = getMoment('tuesday', 9, 0, 'Europe/London');
       expect(openingTimes.nextOpen(date).format()).to.equal(expectedOpeningDateTime.format());
     });
     it('when after fridays closing time should return mondays opening time', () => {
-      const date = getMoment('friday', 18, 30);
+      const date = getMoment('friday', 18, 30, 'Europe/London');
       const expectedOpeningDateTime =
         moment(date)
           .add(3, 'days')
@@ -60,43 +73,43 @@ describe('OpeningTimes', () => {
       expect(openingTimes.nextOpen(date).format()).to.equal(expectedOpeningDateTime.format());
     });
     it('when currently open should return the passed date', () => {
-      const date = getMoment('monday', 11, 30);
+      const date = getMoment('monday', 11, 30, 'Europe/London');
       const expectedOpeningDateTime = moment(date);
       expect(openingTimes.nextOpen(date).format()).to.equal(expectedOpeningDateTime.format());
     });
   });
   describe('nextClosed()', () => {
     it('when currently open should return todays closing time', () => {
-      const date = getMoment('monday', 11, 30);
-      const expectedClosingDateTime = getMoment('monday', 17, 30);
+      const date = getMoment('monday', 11, 30, 'Europe/London');
+      const expectedClosingDateTime = getMoment('monday', 17, 30, 'Europe/London');
       expect(openingTimes.nextClosed(date).format()).to.equal(expectedClosingDateTime.format());
     });
     it('when currently closed should return the passed date', () => {
-      const date = getMoment('monday', 21, 30);
+      const date = getMoment('monday', 21, 30, 'Europe/London');
       const expectedClosingDateTime = moment(date);
       expect(openingTimes.nextClosed(date).format()).to.equal(expectedClosingDateTime.format());
     });
     it('when closing time is after midnight should return tomorrows closing time', () => {
-      const date = getMoment('thursday', 21, 30);
-      const expectedClosingDateTime = getMoment('friday', 1, 30);
+      const date = getMoment('thursday', 21, 30, 'Europe/London');
+      const expectedClosingDateTime = getMoment('friday', 1, 30, 'Europe/London');
       expect(openingTimes.nextClosed(date).format()).to.equal(expectedClosingDateTime.format());
     });
   });
   describe('getOpeningHoursMessage()', () => {
     it('when currently open should return open message', () => {
-      const date = getMoment('monday', 11, 30);
+      const date = getMoment('monday', 11, 30, 'Europe/London');
       expect(openingTimes.getOpeningHoursMessage(date)).to.equal('Open until 5:30 pm today');
     });
     it('when currently closed and opening tomorrow should return closed message', () => {
-      const date = getMoment('monday', 7, 0);
+      const date = getMoment('monday', 7, 0, 'Europe/London');
       expect(openingTimes.getOpeningHoursMessage(date)).to.equal('Closed until 9:00 am today');
     });
     it('when currently closed and opening in 2 hours should return closed message', () => {
-      const date = getMoment('monday', 7, 0);
+      const date = getMoment('monday', 7, 0, 'Europe/London');
       expect(openingTimes.getOpeningHoursMessage(date)).to.equal('Closed until 9:00 am today');
     });
     it('when currently closed and opening in 30 minutes should return closed message', () => {
-      const date = getMoment('monday', 8, 30);
+      const date = getMoment('monday', 8, 30, 'Europe/London');
       expect(openingTimes.getOpeningHoursMessage(date)).to.equal('Opening in 30 minutes');
     });
   });


### PR DESCRIPTION
Code previously assumed that the opening times were in Europe/London TZ. This has now been parameterised.

This will improve the general utility of the class.