### PR TITLE
:cherry_blossom: Change format expected by opening times parameter to be cleaner JSON. 

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
+node_modules/
 coverage/
 public/js/tracking

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,17 +1,12 @@
 {
   "env": {
     "node": true,
-      "mocha": true
+    "mocha": true
   },
-    "extends": [
-      "eslint:recommended",
-    "airbnb"
-    ],
-    "plugins": [
-      "json",
-    "mocha"
-    ],
-    "rules": {
-      "import/no-extraneous-dependencies": ["error", {"devDependencies": true}]
-    }
+  "extends": [ "eslint:recommended", "airbnb" ],
+  "plugins": [ "json", "mocha" ],
+  "rules": {
+    "import/no-extraneous-dependencies": ["error", {"devDependencies": true}],
+    "no-underscore-dangle": ["error", { "allowAfterThis": true }]
+  }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: node_js
 node_js:
-  - "node"
+- node
 script:
-  - npm run lint .
-  - npm run test
-  - npm run generate-coverage
-  - npm run check-coverage
-  - npm run upload-coverage
+- npm run lint .
+- npm run test
+- npm run generate-coverage
+- npm run check-coverage
+- npm run upload-coverage
+notifications:
+  slack:
+    rooms:
+      secure: 0PjBzZxeFqXWjk903oQsuH22WVtHagx5M9aDwIskZ+guSO+Hcx/wNCNFNX7Humq80Gs8J7Fjjq4eVY0ya/WZ88kCQ0l2m4sK2ggaduS2LscdFM3PdZmZR5JJD4DLTQD8Td9+GY30KXikWgZ36qboMz+PTNkPPEwAqcfRfZT/iNBRqafX7g63uS1CsM7GYmfMiXfs/yIOdABAWlWvdFRHvycv32aXu5DTY+JK+7xdhdkBpHpO/3busQfxTBxlzYyFRiGrp2BA9mrrsEKO1NPh7IsU7Ur1NuWeFuFL/pO3o33eWBfX0sbmJYEew5hBtZkiEmP0h/L3Lcdj0RRekZuVuGgfSSOsCdfBWGaVzxx6QjRVzS+wRxPToZV3h2VxbUBtmdnHbmr3fPSGdJGzozNe43D6K4L14zCN5WLK6//gk6VlQMJRDiUo9MzGszOwYkuOO1oRc0qEaB19qK1PEA7jSzw7zPsk0Uey04MhSNJrcv3WWEjm994meKr3EmpbmN5w6HA0Qn6d6nnDjjkrulgJFhlly/P9iiSpFwHFJWZQN4Ir6GO5jOIc77352zBrY/bpgpTHSUQ+fOqmJIUzs7NP05q0xKVk995WnD4sdLk/BHQ8WmV7hERlhNd/9pxoBfPw3Zv1IGhaH/mg/tg5FOSmMdct9yhiR3HyuABM9ZMX1mM=

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
 - node
 script:
-- npm run lint .
+- npm run lint
 - npm run test
 - npm run generate-coverage
 - npm run check-coverage

--- a/OpeningTimes.js
+++ b/OpeningTimes.js
@@ -180,23 +180,22 @@ class OpeningTimes {
         `Open until ${closedTime} ${closedDay}`);
     }
     const openNext = this.nextOpen(datetime);
-
-    if (openNext) {
-      const timeUntilOpen = openNext.diff(datetime, 'minutes');
-      const openDay = openNext.calendar(datetime, {
-        sameDay: '[today]',
-        nextDay: '[tomorrow]',
-        nextWeek: 'dddd',
-        lastDay: '[yesterday]',
-        lastWeek: '[last] dddd',
-        sameElse: 'DD/MM/YYYY',
-      });
-      return (
-	(timeUntilOpen <= 60) ?
+    if (!openNext) {
+      return 'Call for opening times.';
+    }
+    const timeUntilOpen = openNext.diff(datetime, 'minutes');
+    const openDay = openNext.calendar(datetime, {
+      sameDay: '[today]',
+      nextDay: '[tomorrow]',
+      nextWeek: 'dddd',
+      lastDay: '[yesterday]',
+      lastWeek: '[last] dddd',
+      sameElse: 'DD/MM/YYYY',
+    });
+    return (
+      (timeUntilOpen <= 60) ?
         `Opening in ${timeUntilOpen} minutes` :
         `Closed until ${openNext.format('h:mm a')} ${openDay}`);
-    }
-    return 'The next opening time is unknown.';
   }
 
   getFormattedOpeningTimes() {

--- a/OpeningTimes.js
+++ b/OpeningTimes.js
@@ -7,6 +7,7 @@ const weekdays = require('moment').weekdays().map(d => d.toLowerCase());
 
 class OpeningTimes {
   constructor(openingTimes, timeZone) {
+    assert(openingTimes, 'parameter \'openingTimes\' undefined/empty');
     const parameterWeek = Object.keys(openingTimes).sort();
     assert.deepEqual(
       parameterWeek, weekdays.sort(),
@@ -122,14 +123,13 @@ class OpeningTimes {
     return nextClosingTime;
   }
 
-  _formatTime(timeString) {
-    const aDate = moment('2016-07-25T00:00:00+01:00');
-    const time = this._getTimeFromString(timeString);
-    const formattedTime = this._getTime(aDate, time.hours, time.minutes).format('h:mm a');
-    if (formattedTime === '12:00 am' || formattedTime === '11:59 pm') {
+  _formatTime(timeString, formatString = 'h:mm a') {
+    if (timeString === '00:00' || timeString === '23:59') {
       return 'midnight';
     }
-    return formattedTime;
+    const aDate = moment('2016-07-25T00:00:00+01:00');
+    const time = this._getTimeFromString(timeString);
+    return this._getTime(aDate, time.hours, time.minutes).format(formatString);
   }
 
   /* Public API */
@@ -206,15 +206,15 @@ class OpeningTimes {
         `Closed until ${openNext.format('h:mm a')} ${openDay}`);
   }
 
-  getFormattedOpeningTimes() {
+  getFormattedOpeningTimes(formatString) {
     const openingTimes = {};
 
     moment.weekdays().forEach((d) => {
       const day = d.toLowerCase();
       openingTimes[day] = this.openingTimes[day].map((t) =>
         ({
-          opens: this._formatTime(t.opens),
-          closes: this._formatTime(t.closes),
+          opens: this._formatTime(t.opens, formatString),
+          closes: this._formatTime(t.closes, formatString),
         })
       );
     });

--- a/OpeningTimes.js
+++ b/OpeningTimes.js
@@ -1,15 +1,23 @@
+const assert = require('assert');
+const util = require('util');
 const moment = require('moment');
 require('moment-timezone');
-const assert = require('assert');
+
+const weekdays = require('moment').weekdays().map(d => d.toLowerCase());
 
 class OpeningTimes {
   constructor(openingTimes, timeZone) {
-    assert(openingTimes, 'parameter \'openingTimes\' undefined/empty');
-    assert(timeZone, 'parameter \'timeZone\' undefined/empty');
-    assert(timeZone, 'Missing TimeZone');
-    assert(moment.tz.zone(timeZone),
-      `parameter \'timeZone\' is not a valid TimeZone (${timeZone})`);
+    const parameterWeek = Object.keys(openingTimes).sort();
+    assert.deepEqual(
+      parameterWeek, weekdays.sort(),
+      `parameter 'openingTimes' should have all days of the week (${parameterWeek})`);
+    assert(
+      weekdays.every((d) => Array.isArray(openingTimes[d])),
+      'parameter \'openingTimes\' should define opening times for each day.' +
+      ` (${util.inspect(openingTimes)})`);
 
+    assert(timeZone, 'parameter \'timeZone\' undefined/empty');
+    assert(moment.tz.zone(timeZone), 'parameter \'timeZone\' not a valid timezone');
     this.openingTimes = openingTimes;
     this.timeZone = timeZone;
   }

--- a/OpeningTimes.js
+++ b/OpeningTimes.js
@@ -183,17 +183,16 @@ class OpeningTimes {
     return 'The next opening time is unknown.';
   }
 
-  formatTime(timeString) {
+  formatTime(timeString, formatString = 'h:mm a') {
     const aDate = moment('2016-07-25T00:00:00+01:00');
-    const time = this.getTimeFromString(timeString);
-    const formattedTime = this.getTime(aDate, time.hours, time.minutes).format('h:mm a');
-    if (formattedTime === '12:00 am' || formattedTime === '11:59 pm') {
+    if (timeString === '00:00' || timeString === '23:59') {
       return 'midnight';
     }
-    return formattedTime;
+    const time = this.getTimeFromString(timeString);
+    return this.getTime(aDate, time.hours, time.minutes).format(formatString);
   }
 
-  getFormattedOpeningTimes() {
+  getFormattedOpeningTimes(formatString) {
     const openingTimes = {};
 
     moment.weekdays().forEach((d) => {
@@ -204,8 +203,8 @@ class OpeningTimes {
             return 'Closed';
           }
           return {
-            fromTime: this.formatTime(t.fromTime),
-            toTime: this.formatTime(t.toTime),
+            fromTime: this.formatTime(t.fromTime, formatString),
+            toTime: this.formatTime(t.toTime, formatString),
           };
         }),
       };

--- a/bin/preinstall.js
+++ b/bin/preinstall.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const resolve = require('path').resolve;
+const join = require('path').join;
+const cp = require('child_process');
+
+const lib = resolve(__dirname, '../lib/parsers');
+
+function isModuleDirectory(directory) {
+  return fs.existsSync(join(directory, 'package.json'));
+}
+
+fs.readdirSync(lib).forEach((d) => {
+  const fullPath = join(lib, d);
+
+  if (isModuleDirectory(fullPath)) {
+    cp.spawn('npm', ['i'], { env: process.env, cwd: fullPath, stdio: 'inherit' });
+  }
+});

--- a/lib/parsers/nhs-choices-syndication/package.json
+++ b/lib/parsers/nhs-choices-syndication/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "nhs-choices-syndication",
+  "version": "1.0.0",
+  "description": "",
+  "main": "nhs-choices-syndication.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "mocha --recursive test"
+  },
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "mocha": "^3.1.2",
+    "moment": "^2.15.1",
+    "verror": "^1.8.1"
+  },
+  "dependencies": {
+    "json-query": "^2.2.0",
+    "moment-timezone": "^0.5.6",
+    "xml2js": "^0.4.17"
+  }
+}

--- a/lib/parsers/nhs-choices-syndication/parser.js
+++ b/lib/parsers/nhs-choices-syndication/parser.js
@@ -1,0 +1,55 @@
+const xml2js = require('xml2js');
+const jsonQuery = require('json-query');
+const stripPrefix = require('xml2js/lib/processors').stripPrefix;
+const assert = require('assert');
+const Verror = require('verror');
+
+const parseOpeningTimesFromSyndicationXml = (openingTimesType, xml) => {
+  assert(openingTimesType, 'parameter \'openingTimesType\' undefined/empty');
+  assert(xml, 'parameter \'xml\' undefined/empty');
+  assert.equal(typeof (openingTimesType),
+    'string', 'parameter \'openingTimesType\' must be a string');
+  assert.equal(typeof (xml),
+    'string', 'parameter \'xml\' must be a string');
+  const openingTimes = {};
+  const options = {
+    tagNameProcessors: [stripPrefix],
+  };
+  const xmlParser = new xml2js.Parser(options);
+  xmlParser.parseString(xml, (err, result) => {
+    if (err) {
+      throw new Verror(err, 'Unable to parse opening times XML');
+    }
+
+    let openingTimesForType = null;
+    try {
+      if (result.feed.entry[0].content[0].overview[0].openingTimes) {
+        const allOpeningTimes =
+          result.feed.entry[0].content[0].overview[0].openingTimes[0].timesSessionTypes[0];
+
+        openingTimesForType = jsonQuery('timesSessionType[*:isType]', {
+          data: allOpeningTimes,
+          locals: {
+            isType: (item) => item.$.sessionType === openingTimesType,
+          },
+        }).value[0];
+
+        openingTimesForType.daysOfWeek[0].dayOfWeek.forEach((item) => {
+          const dayName = item.dayName[0].toLowerCase();
+          openingTimes[dayName] = [];
+          item.timesSessions[0].timesSession.forEach((t) => {
+            if (t.fromTime) {
+              // session details are a time range
+              openingTimes[dayName].push({ opens: t.fromTime[0], closes: t.toTime[0] });
+            }
+          });
+        });
+      }
+    } catch (e) {
+      throw new Verror(e, `Unable to get '${openingTimesType}' opening times from xml`);
+    }
+  });
+  return openingTimes;
+};
+
+module.exports = parseOpeningTimesFromSyndicationXml;

--- a/lib/parsers/nhs-choices-syndication/test/parser.js
+++ b/lib/parsers/nhs-choices-syndication/test/parser.js
@@ -22,7 +22,7 @@ function assertOpeningTimes(openingTimes, day, expectedOpeningTimes) {
   expect(openingTimes[day])
       .to.eql(getOpeningTimes(expectedOpeningTimes));
 }
-describe('openingTimesParser', () => {
+describe('Syndication Opening Times Parser', () => {
   describe('happy path', () => {
     it('should get opening times from syndication response', () => {
       const syndicationXml = getSampleResponse('pharmacy_opening_times');

--- a/lib/parsers/nhs-choices-syndication/test/parser.js
+++ b/lib/parsers/nhs-choices-syndication/test/parser.js
@@ -1,0 +1,108 @@
+const Verror = require('verror');
+const AssertionError = require('assert').AssertionError;
+const openingTimesParser = require('../parser');
+const OpeningTimes = require('../../../../OpeningTimes');
+const moment = require('moment');
+require('moment-timezone');
+const getSampleResponse = require('./resources/getSampleResponse');
+const weekdays = require('moment').weekdays().map(d => d.toLowerCase());
+const chai = require('chai');
+
+const expect = chai.expect;
+
+function getOpeningTimes(openingTimes) {
+  return openingTimes.map((ot) => ({ opens: ot[0], closes: ot[1] }));
+}
+
+function assertClosed(openingTimes, day) {
+  expect(openingTimes[day]).to.eql([]);
+}
+
+function assertOpeningTimes(openingTimes, day, expectedOpeningTimes) {
+  expect(openingTimes[day])
+      .to.eql(getOpeningTimes(expectedOpeningTimes));
+}
+describe('openingTimesParser', () => {
+  describe('happy path', () => {
+    it('should get opening times from syndication response', () => {
+      const syndicationXml = getSampleResponse('pharmacy_opening_times');
+      const openingTimes = openingTimesParser('general', syndicationXml);
+      expect(openingTimes).to.have.keys(weekdays);
+      assertOpeningTimes(openingTimes, 'monday',
+        [['08:00', '13:00'], ['13:00', '19:30']]);
+      assertOpeningTimes(openingTimes, 'friday',
+        [['08:00', '13:00'], ['13:00', '18:00']]);
+      assertClosed(openingTimes, 'sunday');
+    });
+    it('opening times should be in a format handled by OpeningTimes module', () => {
+      const syndicationXml = getSampleResponse('pharmacy_opening_times');
+      const openingTimesJson = openingTimesParser('general', syndicationXml);
+      const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
+      const aMonday = moment('2016-07-25T10:00:0000');
+      expect(openingTimes.isOpen(moment(aMonday))).to.equal(true);
+    });
+    it('should handle missing opening times', () => {
+      const syndicationXml = getSampleResponse('pharmacy_no_opening_times');
+      const openingTimes = openingTimesParser('general', syndicationXml);
+      expect(openingTimes).to.eql({});
+    });
+  });
+  describe('error handling', () => {
+    it('should throw exception when arguments are missing', () => {
+      expect(() => { openingTimesParser(); })
+        .to.throw(
+          AssertionError,
+          'parameter \'openingTimesType\' undefined/empty');
+      expect(() => { openingTimesParser('reception'); })
+        .to.throw(
+          AssertionError,
+          'parameter \'xml\' undefined/empty');
+    });
+    it('should throw exception when arguments are of the wrong type', () => {
+      expect(() => { openingTimesParser(1, 2); })
+        .to.throw(
+          AssertionError,
+          'parameter \'openingTimesType\' must be a string');
+      expect(() => { openingTimesParser('reception', 2); })
+        .to.throw(
+          AssertionError,
+          'parameter \'xml\' must be a string');
+    });
+    it('should throw exception when passed invalid XML', () => {
+      const syndicationXml = '<invalidxmldocument>';
+      expect(() => { openingTimesParser('reception', syndicationXml); })
+        .to.throw(Verror,
+          'Unable to parse opening times XML: Unclosed root tag');
+    });
+    it('should throw exception when passed an unknown opening times type', () => {
+      const syndicationXml = getSampleResponse('pharmacy_opening_times');
+      expect(() => { openingTimesParser('unknown', syndicationXml); })
+        .to.throw(
+          Verror,
+          'Unable to get \'unknown\' opening times from xml: ' +
+          'Cannot read property \'daysOfWeek\' of undefined');
+    });
+    it('should throw exception when passed an empty opening times type', () => {
+      const syndicationXml = 'not empty';
+      expect(() => { openingTimesParser('', syndicationXml); })
+        .to.throw(
+          AssertionError,
+          'parameter \'openingTimesType\' undefined/empty');
+    });
+    it('should throw exception when passed an empty xml string', () => {
+      const syndicationXml = '';
+      expect(() => { openingTimesParser('reception', syndicationXml); })
+        .to.throw(
+          AssertionError,
+          'parameter \'xml\' undefined/empty');
+    });
+    it('should throw exception when xml does not contain organisation opening times.', () => {
+      const syndicationXml = '<xml></xml>';
+      expect(() => { openingTimesParser('reception', syndicationXml); })
+        .to.throw(
+          Verror,
+          'Unable to get \'reception\' opening times from xml: ' +
+          'Cannot read property \'entry\' of undefined');
+    });
+  });
+});

--- a/lib/parsers/nhs-choices-syndication/test/resources/getSampleResponse.js
+++ b/lib/parsers/nhs-choices-syndication/test/resources/getSampleResponse.js
@@ -1,0 +1,10 @@
+const fs = require('fs');
+
+const sampleResponsesDir = './test/resources';
+
+function getSampleResponse(responseName) {
+  return fs.readFileSync(`${sampleResponsesDir}/${responseName}.xml`).toString();
+}
+
+module.exports = getSampleResponse;
+

--- a/lib/parsers/nhs-choices-syndication/test/resources/getSampleResponse.js
+++ b/lib/parsers/nhs-choices-syndication/test/resources/getSampleResponse.js
@@ -1,9 +1,7 @@
 const fs = require('fs');
 
-const sampleResponsesDir = './test/resources';
-
 function getSampleResponse(responseName) {
-  return fs.readFileSync(`${sampleResponsesDir}/${responseName}.xml`).toString();
+  return fs.readFileSync(`${__dirname}/${responseName}.xml`).toString();
 }
 
 module.exports = getSampleResponse;

--- a/lib/parsers/nhs-choices-syndication/test/resources/pharmacy_no_opening_times.xml
+++ b/lib/parsers/nhs-choices-syndication/test/resources/pharmacy_no_opening_times.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title type="text">NHS Choices - Roman Road Pharmacy - Overview</title>
+  <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/4621446/overview</id>
+  <rights type="text">© Crown Copyright 2009</rights>
+  <updated>2015-07-10T02:40:39+01:00</updated>
+  <category term="Overview" />
+  <logo>http://www.nhs.uk/nhscwebservices/documents/logo1.jpg</logo>
+  <author>
+    <name>NHS Choices</name>
+    <uri>http://www.nhs.uk</uri>
+    <email>webservices@nhschoices.nhs.uk</email>
+  </author>
+  <link rel="self" type="application/xml" title="NHS Choices - Roman Road Pharmacy - Overview" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/4621446/overview?apikey=bbccdd" />
+  <link rel="alternate" title="NHS Choices - Roman Road Pharmacy - Overview" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=110361" />
+  <tracking xmlns="http://syndication.nhschoices.nhs.uk/services">&lt;img style="border: 0; width: 1px; height: 1px;" alt="" src="http://statse.webtrendslive.com/dcss9yzisf9xjyg74mgbihg8p_8d2u/njs.gif?dcsuri=/organisations%2fpharmacies%2f4621446%2foverview&amp;amp;wt.js=no&amp;amp;wt.cg_n=syndication"/&gt;</tracking>
+  <complete xmlns="http://purl.org/syndication/history/1.0" />
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/4621446/overview</id>
+    <title type="text">Roman Road Pharmacy - Overview</title>
+    <published>2015-07-10T02:40:39+01:00</published>
+    <updated>2015-07-10T02:40:39+01:00</updated>
+    <link rel="self" title="Roman Road Pharmacy - Overview" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/4621446/overview?apikey=bbccdd" />
+    <link rel="alternate" title="Roman Road Pharmacy - Overview" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=110361" />
+    <content type="application/xml">
+      <s:overview xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name indexLetter="R">Roman Road Pharmacy</s:name>
+        <s:odsCode>FCV07</s:odsCode>
+        <s:parentOrganisation>
+          <s:name>Durham, Darlington And Tees Area Team</s:name>
+          <s:uri>http://v1.syndication.nhschoices.nhs.uk/organisations/localareateams/463121?apikey=bbccdd</s:uri>
+        </s:parentOrganisation>
+        <s:address>
+          <s:addressLine>31-33 Roman Road</s:addressLine>
+          <s:addressLine>Middlesbrough</s:addressLine>
+          <s:postcode>TS5 6DZ</s:postcode>
+        </s:address>
+        <s:contact type="General">
+          <s:telephone>01642 829095</s:telephone>
+        </s:contact>
+        <s:geographicCoordinates>
+          <s:longitude>-1.24778854846954</s:longitude>
+          <s:latitude>54.5573577880859</s:latitude>
+        </s:geographicCoordinates>
+        <s:overviewLastUpdated>2015-07-10 03:31:04Z</s:overviewLastUpdated>
+        <s:isEpsEnabled>true</s:isEpsEnabled>
+      </s:overview>
+    </content>
+  </entry>
+</feed>

--- a/lib/parsers/nhs-choices-syndication/test/resources/pharmacy_opening_times.xml
+++ b/lib/parsers/nhs-choices-syndication/test/resources/pharmacy_opening_times.xml
@@ -1,0 +1,140 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title type="text">NHS Choices - LloydsPharmacy - Overview</title>
+  <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/34617/overview</id>
+  <rights type="text">Ã‚Â© Crown Copyright 2009</rights>
+  <updated>2015-05-22T20:39:13+01:00</updated>
+  <category term="Overview" />
+  <logo>http://www.nhs.uk/nhscwebservices/documents/logo1.jpg</logo>
+  <author>
+    <name>NHS Choices</name>
+    <uri>http://www.nhs.uk</uri>
+    <email>
+      <a class="__cf_email__" href="/cdn-cgi/l/email-protection" data-cfemail="611604031204131708020412210f091202090e080204124f0f09124f140a">[email protected]</a>
+      <script data-cfhash="f9e31" type="text/javascript">/* <![CDATA[ */!function(t,e,r,n,c,a,p){try{t=document.currentScript||function(){for(t=document.getElementsByTagName('script'),e=t.length;e--;)if(t[e].getAttribute('data-cfhash'))return t[e]}();if(t&&(c=t.previousSibling)){p=t.parentNode;if(a=c.getAttribute('data-cfemail')){for(e='',r='0x'+a.substr(0,2)|0,n=2;a.length-n;n+=2)e+='%'+('0'+('0x'+a.substr(n,2)^r).toString(16)).slice(-2);p.replaceChild(document.createTextNode(decodeURIComponent(e)),c)}p.removeChild(t)}}catch(u){}}()/* ]]> */</script>
+    </email>
+  </author>
+  <link rel="self" type="application/xml" title="NHS Choices - LloydsPharmacy - Overview" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/34617/overview?apikey=bbccdd" />
+  <link rel="alternate" title="NHS Choices - LloydsPharmacy - Overview" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=12332" />
+  <tracking xmlns="http://syndication.nhschoices.nhs.uk/services">
+    <img style="border: 0; width: 1px; height: 1px;" alt="" src="http://statse.webtrendslive.com/dcss9yzisf9xjyg74mgbihg8p_8d2u/njs.gif?dcsuri=/organisations%2fpharmacies%2f34617%2foverview&amp;wt.js=no&amp;wt.cg_n=syndication" />
+  </tracking>
+  <complete xmlns="http://purl.org/syndication/history/1.0" />
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/34617/overview</id>
+    <title type="text">LloydsPharmacy - Overview</title>
+    <published>2015-05-22T20:39:13+01:00</published>
+    <updated>2015-05-22T20:39:13+01:00</updated>
+    <link rel="self" title="LloydsPharmacy - Overview" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/34617/overview?apikey=bbccdd" />
+    <link rel="alternate" title="LloydsPharmacy - Overview" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=12332" />
+    <content type="application/xml">
+      <s:overview xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name indexLetter="L">LloydsPharmacy</s:name>
+        <s:odsCode>FTK79</s:odsCode>
+        <s:parentOrganisation>
+          <s:name>North Yorkshire And Humber Area Team</s:name>
+          <s:uri>http://v1.syndication.nhschoices.nhs.uk/organisations/localareateams/463126?apikey=bbccdd</s:uri>
+        </s:parentOrganisation>
+        <s:address>
+          <s:addressLine>34 High Street</s:addressLine>
+          <s:addressLine>Knaresborough</s:addressLine>
+          <s:addressLine>North Yorkshire</s:addressLine>
+          <s:addressLine>Knaresborough</s:addressLine>
+          <s:addressLine>North Yorkshire</s:addressLine>
+          <s:postcode>HG5 0EQ</s:postcode>
+        </s:address>
+        <s:contact type="General">
+          <s:telephone>01423 865308</s:telephone>
+          <s:email>
+            <a class="__cf_email__" href="/cdn-cgi/l/email-protection" data-cfemail="7a160a4c4c4e4a3a361615031e090a121b08171b1903541915540f11">[email protected]</a>
+            <script data-cfhash="f9e31" type="text/javascript">/* <![CDATA[ */!function(t,e,r,n,c,a,p){try{t=document.currentScript||function(){for(t=document.getElementsByTagName('script'),e=t.length;e--;)if(t[e].getAttribute('data-cfhash'))return t[e]}();if(t&&(c=t.previousSibling)){p=t.parentNode;if(a=c.getAttribute('data-cfemail')){for(e='',r='0x'+a.substr(0,2)|0,n=2;a.length-n;n+=2)e+='%'+('0'+('0x'+a.substr(n,2)^r).toString(16)).slice(-2);p.replaceChild(document.createTextNode(decodeURIComponent(e)),c)}p.removeChild(t)}}catch(u){}}()/* ]]> */</script>
+          </s:email>
+        </s:contact>
+        <s:website>http://www.lloydspharmacy.com</s:website>
+        <s:geographicCoordinates>
+          <s:longitude>-1.46577370166779</s:longitude>
+          <s:latitude>54.0081405639648</s:latitude>
+        </s:geographicCoordinates>
+        <s:openingTimes>
+          <s:timesSessionTypes>
+            <s:timesSessionType sessionType="general">
+              <s:daysOfWeek>
+                <s:dayOfWeek>
+                  <s:dayName>Sunday</s:dayName>
+                  <s:timesSessions>
+                    <s:timesSession>Closed</s:timesSession>
+                  </s:timesSessions>
+                </s:dayOfWeek>
+                <s:dayOfWeek>
+                  <s:dayName>Monday</s:dayName>
+                  <s:timesSessions>
+                    <s:timesSession>
+                      <s:fromTime>08:00</s:fromTime>
+                      <s:toTime>13:00</s:toTime>
+                    </s:timesSession>
+                    <s:timesSession>
+                      <s:fromTime>13:00</s:fromTime>
+                      <s:toTime>19:30</s:toTime>
+                    </s:timesSession>
+                  </s:timesSessions>
+                </s:dayOfWeek>
+                <s:dayOfWeek>
+                  <s:dayName>Tuesday</s:dayName>
+                  <s:timesSessions>
+                    <s:timesSession>
+                      <s:fromTime>09:00</s:fromTime>
+                      <s:toTime>17:30</s:toTime>
+                    </s:timesSession>
+                  </s:timesSessions>
+                </s:dayOfWeek>
+                <s:dayOfWeek>
+                  <s:dayName>Wednesday</s:dayName>
+                  <s:timesSessions>
+                    <s:timesSession>
+                      <s:fromTime>09:00</s:fromTime>
+                      <s:toTime>17:30</s:toTime>
+                    </s:timesSession>
+                  </s:timesSessions>
+                </s:dayOfWeek>
+                <s:dayOfWeek>
+                  <s:dayName>Thursday</s:dayName>
+                  <s:timesSessions>
+                    <s:timesSession>
+                      <s:fromTime>09:00</s:fromTime>
+                      <s:toTime>17:30</s:toTime>
+                    </s:timesSession>
+                  </s:timesSessions>
+                </s:dayOfWeek>
+                <s:dayOfWeek>
+                  <s:dayName>Friday</s:dayName>
+                  <s:timesSessions>
+                    <s:timesSession>
+                      <s:fromTime>08:00</s:fromTime>
+                      <s:toTime>13:00</s:toTime>
+                    </s:timesSession>
+                    <s:timesSession>
+                      <s:fromTime>13:00</s:fromTime>
+                      <s:toTime>18:00</s:toTime>
+                    </s:timesSession>
+                  </s:timesSessions>
+                </s:dayOfWeek>
+                <s:dayOfWeek>
+                  <s:dayName>Saturday</s:dayName>
+                  <s:timesSessions>
+                    <s:timesSession>
+                      <s:fromTime>09:00</s:fromTime>
+                      <s:toTime>17:30</s:toTime>
+                    </s:timesSession>
+                  </s:timesSessions>
+                </s:dayOfWeek>
+              </s:daysOfWeek>
+            </s:timesSessionType>
+          </s:timesSessionTypes>
+          <s:lastVerifiedOn>2010-11-12 04:53:03Z</s:lastVerifiedOn>
+        </s:openingTimes>
+        <s:overviewLastUpdated>2010-11-12 04:51:33Z</s:overviewLastUpdated>
+        <s:isEpsEnabled>true</s:isEpsEnabled>
+      </s:overview>
+    </content>
+  </entry>
+</feed>

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "moment-opening-times",
   "version": "1.0.0",
   "description": "A small class to determine the status of a given moment in relation to a set of opening times",
+  "repository" : { "type": "git", "url": "https://github.com/nhsuk/moment-opening-times" },
   "main": "OpeningTimes.js",
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eslint-plugin-mocha": "^4.3.0",
     "eslint-plugin-react": "^6.0.0",
     "eslint-watch": "^2.1.11",
+    "ghooks": "^1.3.2",
     "istanbul": "^0.4.3",
     "mocha": "^3.0.2",
     "mocha-lcov-reporter": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moment-opening-times",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "A small class to determine the status of a given moment in relation to a set of opening times",
   "main": "OpeningTimes.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "mocha-lcov-reporter": "^1.2.0"
   },
   "scripts": {
-    "test": "mocha",
+    "preinstall": "node bin/preinstall",
+    "test": "mocha --recursive test \"lib/parsers/*/test/*.js\"",
     "watch-test": "npm run test -- --watch --reporter min",
     "lint": "eslint --ext .js,.json .",
     "generate-coverage": "istanbul cover _mocha -- --recursive test",

--- a/test/OpeningTimes.js
+++ b/test/OpeningTimes.js
@@ -16,102 +16,71 @@ function getMoment(day, hours, minutes, timeZone) {
   return date;
 }
 
+function getClosedDay() {
+  return [];
+}
+
+function getSingleSessionDay() {
+  return [{ opens: '09:00', closes: '17:30' }];
+}
+
+function getDoubleSessionDay() {
+  return [
+    { opens: '09:00', closes: '12:30' },
+    { opens: '13:30', closes: '17:30' },
+  ];
+}
+
+function getTripleSessionDay() {
+  return [
+    { opens: '09:00', closes: '12:30' },
+    { opens: '13:30', closes: '17:30' },
+    { opens: '18:30', closes: '22:30' },
+  ];
+}
+
+function setUpAllWeek(getTimes) {
+  const week = {};
+
+  moment.weekdays().forEach((d) => {
+    const day = d.toLowerCase();
+    week[day] = getTimes();
+  });
+
+  return week;
+}
+
 function getClosedAllWeek() {
-  /* eslint-disable quote-props, quotes, comma-dangle */
-  return {
-    "monday": [],
-    "tuesday": [],
-    "wednesday": [],
-    "thursday": [],
-    "friday": [],
-    "saturday": [],
-    "sunday": []
-  };
-  /* eslint-enable quote-props, quotes, comma-dangle */
+  return setUpAllWeek(getClosedDay);
 }
 
 function getRegularWorkingWeek() {
-  /* eslint-disable quote-props, quotes, comma-dangle */
-  return {
-    "monday": [{ "opens": "09:00", "closes": "17:30" }],
-    "tuesday": [{ "opens": "09:00", "closes": "17:30" }],
-    "wednesday": [{ "opens": "09:00", "closes": "17:30" }],
-    "thursday": [{ "opens": "09:00", "closes": "17:30" }],
-    "friday": [{ "opens": "09:00", "closes": "17:30" }],
-    "saturday": [{ "opens": "09:00", "closes": "17:30" }],
-    "sunday": []
-  };
-  /* eslint-enable quote-props, quotes, comma-dangle */
+  const week = setUpAllWeek(getSingleSessionDay);
+  week.sunday = getClosedDay();
+  return week;
 }
 
 function getRegularWorkingWeekWithLunchBreaks() {
-  /* eslint-disable quote-props, quotes, comma-dangle */
-  return {
-    "monday": [
-      { "opens": "09:00", "closes": "12:30" },
-      { "opens": "13:30", "closes": "17:30" },
-    ],
-    "tuesday": [
-      { "opens": "09:00", "closes": "12:30" },
-      { "opens": "13:30", "closes": "17:30" },
-    ],
-    "wednesday": [
-      { "opens": "09:00", "closes": "12:30" },
-      { "opens": "13:30", "closes": "17:30" },
-    ],
-    "thursday": [
-      { "opens": "09:00", "closes": "12:30" },
-      { "opens": "13:30", "closes": "17:30" },
-    ],
-    "friday": [
-      { "opens": "09:00", "closes": "12:30" },
-      { "opens": "13:30", "closes": "17:30" },
-    ],
-    "saturday": [
-      { "opens": "09:00", "closes": "12:30" },
-      { "opens": "13:30", "closes": "17:30" },
-    ],
-    "sunday": []
-  };
-  /* eslint-enable quote-props, quotes, comma-dangle */
+  const week = setUpAllWeek(getDoubleSessionDay);
+  week.sunday = getClosedDay();
+  return week;
 }
 
 function getRegularWorkingWeekWithLunchBreaksAndEveningSession() {
-  /* eslint-disable quote-props, quotes, comma-dangle */
-  return {
-    "monday": [
-      { "opens": "09:00", "closes": "12:30" },
-      { "opens": "13:30", "closes": "17:30" },
-      { "opens": "18:30", "closes": "22:30" }
-    ],
-    "tuesday": [
-      { "opens": "09:00", "closes": "12:30" },
-      { "opens": "13:30", "closes": "17:30" },
-      { "opens": "18:30", "closes": "22:30" }
-    ],
-    "wednesday": [
-      { "opens": "09:00", "closes": "12:30" },
-      { "opens": "13:30", "closes": "17:30" },
-      { "opens": "18:30", "closes": "22:30" }
-    ],
-    "thursday": [
-      { "opens": "09:00", "closes": "12:30" },
-      { "opens": "13:30", "closes": "17:30" },
-      { "opens": "18:30", "closes": "22:30" }
-    ],
-    "friday": [
-      { "opens": "09:00", "closes": "12:30" },
-      { "opens": "13:30", "closes": "17:30" },
-      { "opens": "18:30", "closes": "22:30" }
-    ],
-    "saturday": [
-      { "opens": "09:00", "closes": "12:30" },
-      { "opens": "13:30", "closes": "17:30" },
-      { "opens": "18:30", "closes": "22:30" }
-    ],
-    "sunday": []
-  };
-  /* eslint-enable quote-props, quotes, comma-dangle */
+  const week = setUpAllWeek(getTripleSessionDay);
+  week.sunday = getClosedDay();
+  return week;
+}
+
+function clone(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+function getRegularWorkingWeekWithCustomSession(session) {
+  const getCustomSession = () => (clone(session));
+  const week = setUpAllWeek(getCustomSession);
+  week.sunday = getClosedDay();
+  return week;
 }
 
 describe('OpeningTimes', () => {
@@ -291,34 +260,22 @@ describe('OpeningTimes', () => {
       expect(openingTimes.nextClosed(date).format()).to.equal(expectedClosingDateTime.format());
     });
     it('should handle closing time of midnight', () => {
-      /* eslint-disable quote-props, quotes, comma-dangle */
-      const openingTimesJson = {
-        "monday": [
-          {
-            "opens": "09:00",
-            "closes": "17:30"
-          },
-          {
-            "opens": "18:30",
-            "closes": "00:00"
-          }
-        ]
-      };
-      /* eslint-enable quote-props, quotes, comma-dangle */
+      const openingTimesJson = getRegularWorkingWeekWithCustomSession(
+        [
+          { opens: '09:00', closes: '17:30' },
+          { opens: '18:30', closes: '00:00' },
+        ]);
       const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
       const date = getMoment('monday', 21, 30, 'Europe/London');
       const expectedClosingDateTime = getMoment('tuesday', 0, 0, 'Europe/London');
       expect(openingTimes.nextClosed(date).format()).to.equal(expectedClosingDateTime.format());
     });
     it('should handle closing time of after midnight', () => {
-      /* eslint-disable quote-props, quotes, comma-dangle */
-      const openingTimesJson = {
-        "monday": [
-          { "opens": "09:00", "closes": "17:30" },
-          { "opens": "18:30", "closes": "01:00" }
-        ]
-      };
-      /* eslint-enable quote-props, quotes, comma-dangle */
+      const openingTimesJson = getRegularWorkingWeekWithCustomSession(
+        [
+          { opens: '09:00', closes: '17:30' },
+          { opens: '18:30', closes: '01:00' },
+        ]);
       const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
       const date = getMoment('monday', 21, 30, 'Europe/London');
       const expectedClosingDateTime = getMoment('tuesday', 1, 0, 'Europe/London');
@@ -326,34 +283,38 @@ describe('OpeningTimes', () => {
     });
   });
   describe('getOpeningHoursMessage()', () => {
-    const openingTimesJson = getRegularWorkingWeekWithLunchBreaks();
-    /* eslint-disable quote-props, quotes, comma-dangle */
-    openingTimesJson.monday = [
-      { "opens": "09:00", "closes": "12:30" },
-      { "opens": "13:30", "closes": "17:30" },
-      { "opens": "18:30", "closes": "00:00" }
-    ];
-    /* eslint-enable quote-props, quotes, comma-dangle */
-    const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
-    it('when currently open should return open message', () => {
-      const date = getMoment('monday', 13, 30, 'Europe/London');
-      expect(openingTimes.getOpeningHoursMessage(date)).to.equal('Open until 5:30 pm today');
+    describe('regular opening hours', () => {
+      const openingTimesJson = getRegularWorkingWeekWithLunchBreaks();
+      const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
+      it('when currently closed and opening tomorrow should return closed message', () => {
+        const date = getMoment('tuesday', 18, 0, 'Europe/London');
+        expect(openingTimes.getOpeningHoursMessage(date)).to.equal('Closed until 9:00 am tomorrow');
+      });
+      it('when currently closed and opening in 2 hours should return closed message', () => {
+        const date = getMoment('monday', 7, 0, 'Europe/London');
+        expect(openingTimes.getOpeningHoursMessage(date)).to.equal('Closed until 9:00 am today');
+      });
+      it('when currently closed and opening in 30 minutes should return closed message', () => {
+        const date = getMoment('monday', 8, 30, 'Europe/London');
+        expect(openingTimes.getOpeningHoursMessage(date)).to.equal('Opening in 30 minutes');
+      });
     });
-    it('when currently open and closing at 00:00 should return midnight message', () => {
-      const date = getMoment('monday', 19, 30, 'Europe/London');
-      expect(openingTimes.getOpeningHoursMessage(date)).to.equal('Open until midnight');
-    });
-    it('when currently closed and opening tomorrow should return closed message', () => {
-      const date = getMoment('tuesday', 18, 0, 'Europe/London');
-      expect(openingTimes.getOpeningHoursMessage(date)).to.equal('Closed until 9:00 am tomorrow');
-    });
-    it('when currently closed and opening in 2 hours should return closed message', () => {
-      const date = getMoment('monday', 7, 0, 'Europe/London');
-      expect(openingTimes.getOpeningHoursMessage(date)).to.equal('Closed until 9:00 am today');
-    });
-    it('when currently closed and opening in 30 minutes should return closed message', () => {
-      const date = getMoment('monday', 8, 30, 'Europe/London');
-      expect(openingTimes.getOpeningHoursMessage(date)).to.equal('Opening in 30 minutes');
+    describe('midnight opening hours', () => {
+      const openingTimesJson = getRegularWorkingWeekWithCustomSession(
+        [
+          { opens: '09:00', closes: '12:30' },
+          { opens: '13:30', closes: '17:30' },
+          { opens: '18:30', closes: '00:00' },
+        ]);
+      const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
+      it('when currently open should return open message', () => {
+        const date = getMoment('monday', 13, 30, 'Europe/London');
+        expect(openingTimes.getOpeningHoursMessage(date)).to.equal('Open until 5:30 pm today');
+      });
+      it('when currently open and closing at 00:00 should return midnight message', () => {
+        const date = getMoment('monday', 19, 30, 'Europe/London');
+        expect(openingTimes.getOpeningHoursMessage(date)).to.equal('Open until midnight');
+      });
     });
     it('when closed all week the should return unknown opening time message', () => {
       const closedTimesJson = {
@@ -399,13 +360,11 @@ describe('OpeningTimes', () => {
     });
     it('times should be returned as am/pm', () => {
       const openingTimesJson = getRegularWorkingWeekWithLunchBreaks();
-      /* eslint-disable quote-props, quotes, comma-dangle */
       openingTimesJson.monday = [
-        { "opens": "09:00", "closes": "12:30" },
-        { "opens": "13:30", "closes": "17:30" },
-        { "opens": "18:30", "closes": "00:00" }
+        { opens: '09:00', closes: '12:30' },
+        { opens: '13:30', closes: '17:30' },
+        { opens: '18:30', closes: '00:00' },
       ];
-      /* eslint-enable quote-props, quotes, comma-dangle */
       const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
       const formattedOpeningTimes = openingTimes.getFormattedOpeningTimes();
       expect(formattedOpeningTimes.monday[0].opens).to.equal('9:00 am');

--- a/test/OpeningTimes.js
+++ b/test/OpeningTimes.js
@@ -403,6 +403,31 @@ describe('OpeningTimes', () => {
     });
   });
   describe('formatOpeningTimes()', () => {
+    it('times should be returned as two digit 24 hour', () => {
+      const openingTimesJson = {
+        monday: {
+          times: [
+            { fromTime: '09:00', toTime: '12:30' },
+            { fromTime: '13:30', toTime: '17:30' },
+            { fromTime: '18:30', toTime: '00:00' },
+          ],
+        },
+        tuesday: { times: ['Closed'] },
+        wednesday: { times: ['Closed'] },
+        thursday: { times: ['Closed'] },
+        friday: { times: ['Closed'] },
+        saturday: { times: ['Closed'] },
+        sunday: { times: ['Closed'] },
+      };
+      const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
+      const formattedOpeningTimes = openingTimes.getFormattedOpeningTimes('HH:mm');
+      expect(formattedOpeningTimes.monday.times[0].fromTime).to.equal('09:00');
+      expect(formattedOpeningTimes.monday.times[0].toTime).to.equal('12:30');
+      expect(formattedOpeningTimes.monday.times[1].fromTime).to.equal('13:30');
+      expect(formattedOpeningTimes.monday.times[1].toTime).to.equal('17:30');
+      expect(formattedOpeningTimes.monday.times[2].fromTime).to.equal('18:30');
+      expect(formattedOpeningTimes.monday.times[2].toTime).to.equal('midnight');
+    });
     it('times should be returned as am/pm', () => {
       const openingTimesJson = {
         monday: {

--- a/test/OpeningTimes.js
+++ b/test/OpeningTimes.js
@@ -7,7 +7,10 @@ const expect = chai.expect;
 const aSunday = moment('2016-07-24T00:00:00+00:00');
 
 function getMoment(day, hours, minutes, timeZone) {
-  const dayNumber = moment.weekdays().map((d) => d.toLowerCase()).indexOf(day);
+  const dayNumber = moment
+    .weekdays()
+    .map((d) => d.toLowerCase())
+    .indexOf(day);
   const date = moment(aSunday).tz(timeZone);
   date.add(dayNumber, 'days').hours(hours).minutes(minutes);
   return date;

--- a/test/OpeningTimes.js
+++ b/test/OpeningTimes.js
@@ -16,6 +16,104 @@ function getMoment(day, hours, minutes, timeZone) {
   return date;
 }
 
+function getClosedAllWeek() {
+  /* eslint-disable quote-props, quotes, comma-dangle */
+  return {
+    "monday": [],
+    "tuesday": [],
+    "wednesday": [],
+    "thursday": [],
+    "friday": [],
+    "saturday": [],
+    "sunday": []
+  };
+  /* eslint-enable quote-props, quotes, comma-dangle */
+}
+
+function getRegularWorkingWeek() {
+  /* eslint-disable quote-props, quotes, comma-dangle */
+  return {
+    "monday": [{ "opens": "09:00", "closes": "17:30" }],
+    "tuesday": [{ "opens": "09:00", "closes": "17:30" }],
+    "wednesday": [{ "opens": "09:00", "closes": "17:30" }],
+    "thursday": [{ "opens": "09:00", "closes": "17:30" }],
+    "friday": [{ "opens": "09:00", "closes": "17:30" }],
+    "saturday": [{ "opens": "09:00", "closes": "17:30" }],
+    "sunday": []
+  };
+  /* eslint-enable quote-props, quotes, comma-dangle */
+}
+
+function getRegularWorkingWeekWithLunchBreaks() {
+  /* eslint-disable quote-props, quotes, comma-dangle */
+  return {
+    "monday": [
+      { "opens": "09:00", "closes": "12:30" },
+      { "opens": "13:30", "closes": "17:30" },
+    ],
+    "tuesday": [
+      { "opens": "09:00", "closes": "12:30" },
+      { "opens": "13:30", "closes": "17:30" },
+    ],
+    "wednesday": [
+      { "opens": "09:00", "closes": "12:30" },
+      { "opens": "13:30", "closes": "17:30" },
+    ],
+    "thursday": [
+      { "opens": "09:00", "closes": "12:30" },
+      { "opens": "13:30", "closes": "17:30" },
+    ],
+    "friday": [
+      { "opens": "09:00", "closes": "12:30" },
+      { "opens": "13:30", "closes": "17:30" },
+    ],
+    "saturday": [
+      { "opens": "09:00", "closes": "12:30" },
+      { "opens": "13:30", "closes": "17:30" },
+    ],
+    "sunday": []
+  };
+  /* eslint-enable quote-props, quotes, comma-dangle */
+}
+
+function getRegularWorkingWeekWithLunchBreaksAndEveningSession() {
+  /* eslint-disable quote-props, quotes, comma-dangle */
+  return {
+    "monday": [
+      { "opens": "09:00", "closes": "12:30" },
+      { "opens": "13:30", "closes": "17:30" },
+      { "opens": "18:30", "closes": "22:30" }
+    ],
+    "tuesday": [
+      { "opens": "09:00", "closes": "12:30" },
+      { "opens": "13:30", "closes": "17:30" },
+      { "opens": "18:30", "closes": "22:30" }
+    ],
+    "wednesday": [
+      { "opens": "09:00", "closes": "12:30" },
+      { "opens": "13:30", "closes": "17:30" },
+      { "opens": "18:30", "closes": "22:30" }
+    ],
+    "thursday": [
+      { "opens": "09:00", "closes": "12:30" },
+      { "opens": "13:30", "closes": "17:30" },
+      { "opens": "18:30", "closes": "22:30" }
+    ],
+    "friday": [
+      { "opens": "09:00", "closes": "12:30" },
+      { "opens": "13:30", "closes": "17:30" },
+      { "opens": "18:30", "closes": "22:30" }
+    ],
+    "saturday": [
+      { "opens": "09:00", "closes": "12:30" },
+      { "opens": "13:30", "closes": "17:30" },
+      { "opens": "18:30", "closes": "22:30" }
+    ],
+    "sunday": []
+  };
+  /* eslint-enable quote-props, quotes, comma-dangle */
+}
+
 describe('OpeningTimes', () => {
   describe('constructor', () => {
     it('should not throw for valid parameters', () => {
@@ -40,13 +138,7 @@ describe('OpeningTimes', () => {
   });
   describe('isOpen()', () => {
     describe('single session (9:00 - 17:30)', () => {
-      const openingTimesJson = {
-        monday: {
-          times: [
-            { fromTime: '09:00', toTime: '17:30' },
-          ],
-        },
-      };
+      const openingTimesJson = getRegularWorkingWeek();
       const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
       it('should return true if time is inside opening times', () => {
         const date = getMoment('monday', 11, 30, 'Europe/London');
@@ -58,14 +150,7 @@ describe('OpeningTimes', () => {
       });
     });
     describe('split sessions (9:00 - 12:30, 13:30 - 17:30)', () => {
-      const openingTimesJson = {
-        monday: {
-          times: [
-            { fromTime: '09:00', toTime: '12:30' },
-            { fromTime: '13:30', toTime: '17:30' },
-          ],
-        },
-      };
+      const openingTimesJson = getRegularWorkingWeekWithLunchBreaks();
       const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
       it('should return false if time is during lunchtime', () => {
         const date = getMoment('monday', 13, 0, 'Europe/London');
@@ -89,14 +174,7 @@ describe('OpeningTimes', () => {
       });
     });
     describe('closed', () => {
-      const openingTimesJson = {
-        monday: {
-          times: [
-            { fromTime: '09:00', toTime: '12:30' },
-            'Closed',
-          ],
-        },
-      };
+      const openingTimesJson = getClosedAllWeek();
       const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
       it('should override all other session times', () => {
         const date = getMoment('monday', 10, 0, 'Europe/London');
@@ -105,14 +183,7 @@ describe('OpeningTimes', () => {
     });
     describe('with opening times in different time zones', () => {
       describe('Opening times - London 9:00 - 17:30', () => {
-        const openingTimesJson = {
-          monday: {
-            times: [
-              { fromTime: '09:00', toTime: '12:30' },
-              { fromTime: '13:30', toTime: '17:30' },
-            ],
-          },
-        };
+        const openingTimesJson = getRegularWorkingWeek();
         const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
         it('should return true for 8 am UTC time', () => {
           const date = getMoment('monday', 8, 0, 'UTC');
@@ -120,14 +191,7 @@ describe('OpeningTimes', () => {
         });
       });
       describe('Opening times - Tokyo 9:00 - 17:30', () => {
-        const openingTimesJson = {
-          monday: {
-            times: [
-              { fromTime: '09:00', toTime: '12:30' },
-              { fromTime: '13:30', toTime: '17:30' },
-            ],
-          },
-        };
+        const openingTimesJson = getRegularWorkingWeek();
         const openingTimes = new OpeningTimes(openingTimesJson, 'Asia/Tokyo');
         it('should return true for 8 am London time', () => {
           const date = getMoment('monday', 8, 0, 'Europe/London');
@@ -142,132 +206,62 @@ describe('OpeningTimes', () => {
   });
   describe('nextOpen()', () => {
     it('when closed all week should return undefined', () => {
-      const openingTimesJson = {
-        monday: { times: ['Closed'] },
-        tuesday: { times: ['Closed'] },
-        wednesday: { times: ['Closed'] },
-        thursday: { times: ['Closed'] },
-        friday: { times: ['Closed'] },
-        saturday: { times: ['Closed'] },
-        sunday: { times: ['Closed'] },
-      };
+      const openingTimesJson = getClosedAllWeek();
       const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
       const date = getMoment('monday', 12, 40, 'Europe/London');
       expect(openingTimes.nextOpen(date)).to.equal(undefined);
     });
     it('when closed today should return start of tomorrows morning session', () => {
-      const openingTimesJson = {
-        monday: { times: ['Closed'] },
-        tuesday: {
-          times: [
-            { fromTime: '09:00', toTime: '12:30' },
-            { fromTime: '13:30', toTime: '17:30' },
-          ],
-        },
-      };
+      const openingTimesJson = getRegularWorkingWeek();
+      openingTimesJson.monday = [];
       const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
       const date = getMoment('monday', 12, 40, 'Europe/London');
       const expectedOpeningDateTime = getMoment('tuesday', 9, 0, 'Europe/London');
       expect(openingTimes.nextOpen(date).format()).to.equal(expectedOpeningDateTime.format());
     });
     it('when during lunchtime should return start of afternoon session', () => {
-      const openingTimesJson = {
-        monday: {
-          times: [
-            { fromTime: '09:00', toTime: '12:30' },
-            { fromTime: '13:30', toTime: '17:30' },
-          ],
-        },
-      };
+      const openingTimesJson = getRegularWorkingWeekWithLunchBreaks();
       const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
       const date = getMoment('monday', 12, 40, 'Europe/London');
       const expectedOpeningDateTime = getMoment('monday', 13, 30, 'Europe/London');
       expect(openingTimes.nextOpen(date).format()).to.equal(expectedOpeningDateTime.format());
     });
     it('when during dinnertime should return start of evening session', () => {
-      const openingTimesJson = {
-        monday: {
-          times: [
-            { fromTime: '09:00', toTime: '12:30' },
-            { fromTime: '13:30', toTime: '17:30' },
-            { fromTime: '18:30', toTime: '22:30' },
-          ],
-        },
-      };
+      const openingTimesJson = getRegularWorkingWeekWithLunchBreaksAndEveningSession();
       const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
       const date = getMoment('monday', 17, 40, 'Europe/London');
       const expectedOpeningDateTime = getMoment('monday', 18, 30, 'Europe/London');
       expect(openingTimes.nextOpen(date).format()).to.equal(expectedOpeningDateTime.format());
     });
     it('when before days opening time should return following opening time', () => {
-      const openingTimesJson = {
-        monday: {
-          times: [
-            { fromTime: '09:00', toTime: '12:30' },
-            { fromTime: '13:30', toTime: '17:30' },
-          ],
-        },
-      };
+      const openingTimesJson = getRegularWorkingWeekWithLunchBreaks();
       const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
       const date = getMoment('monday', 8, 30, 'Europe/London');
       const expectedOpeningDateTime = getMoment('monday', 9, 0, 'Europe/London');
       expect(openingTimes.nextOpen(date).format()).to.equal(expectedOpeningDateTime.format());
     });
     it('when after days closing time should return following days opening time', () => {
-      const openingTimesJson = {
-        monday: {
-          times: [
-            { fromTime: '09:00', toTime: '12:30' },
-            { fromTime: '13:30', toTime: '17:30' },
-          ],
-        },
-        tuesday: {
-          times: [
-            { fromTime: '09:00', toTime: '12:30' },
-            { fromTime: '13:30', toTime: '17:30' },
-          ],
-        },
-      };
+      const openingTimesJson = getRegularWorkingWeekWithLunchBreaks();
       const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
       const date = getMoment('monday', 18, 30, 'Europe/London');
       const expectedOpeningDateTime = getMoment('tuesday', 9, 0, 'Europe/London');
       expect(openingTimes.nextOpen(date).format()).to.equal(expectedOpeningDateTime.format());
     });
     it('when after fridays closing time should return mondays opening time', () => {
-      const openingTimesJson = {
-        monday: {
-          times: [
-            { fromTime: '09:00', toTime: '12:30' },
-            { fromTime: '13:30', toTime: '17:30' },
-          ],
-        },
-        friday: {
-          times: [
-            { fromTime: '09:00', toTime: '12:30' },
-            { fromTime: '13:30', toTime: '17:30' },
-          ],
-        },
-        saturday: { times: ['Closed'] },
-        sunday: { times: ['Closed'] },
-      };
+      const openingTimesJson = getRegularWorkingWeek();
+      openingTimesJson.saturday = [];
+      openingTimesJson.sunday = [];
       const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
       const date = getMoment('friday', 18, 30, 'Europe/London');
       const expectedOpeningDateTime =
         moment(date)
-          .add(3, 'days')
-          .hours(9)
-          .minutes(0);
+        .add(3, 'days')
+        .hours(9)
+        .minutes(0);
       expect(openingTimes.nextOpen(date).format()).to.equal(expectedOpeningDateTime.format());
     });
     it('when currently open should return the passed datetime', () => {
-      const openingTimesJson = {
-        monday: {
-          times: [
-            { fromTime: '09:00', toTime: '12:30' },
-            { fromTime: '13:30', toTime: '17:30' },
-          ],
-        },
-      };
+      const openingTimesJson = getRegularWorkingWeek();
       const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
       const date = getMoment('monday', 11, 30, 'Europe/London');
       const expectedOpeningDateTime = moment(date);
@@ -276,70 +270,55 @@ describe('OpeningTimes', () => {
   });
   describe('nextClosed()', () => {
     it('when during morning opening should return lunchtime closing', () => {
-      const openingTimesJson = {
-        monday: {
-          times: [
-            { fromTime: '09:00', toTime: '12:30' },
-            { fromTime: '13:30', toTime: '17:30' },
-          ],
-        },
-      };
+      const openingTimesJson = getRegularWorkingWeekWithLunchBreaks();
       const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
       const date = getMoment('monday', 11, 30, 'Europe/London');
       const expectedClosingDateTime = getMoment('monday', 12, 30, 'Europe/London');
       expect(openingTimes.nextClosed(date).format()).to.equal(expectedClosingDateTime.format());
     });
     it('when during afternoon opening should return evening closing', () => {
-      const openingTimesJson = {
-        monday: {
-          times: [
-            { fromTime: '09:00', toTime: '12:30' },
-            { fromTime: '13:30', toTime: '17:30' },
-          ],
-        },
-      };
+      const openingTimesJson = getRegularWorkingWeekWithLunchBreaks();
       const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
       const date = getMoment('monday', 15, 30, 'Europe/London');
       const expectedClosingDateTime = getMoment('monday', 17, 30, 'Europe/London');
       expect(openingTimes.nextClosed(date).format()).to.equal(expectedClosingDateTime.format());
     });
     it('when currently closed should return the passed date', () => {
-      const openingTimesJson = {
-        monday: {
-          times: [
-            { fromTime: '09:00', toTime: '12:30' },
-            { fromTime: '13:30', toTime: '17:30' },
-          ],
-        },
-      };
+      const openingTimesJson = getRegularWorkingWeekWithLunchBreaks();
       const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
       const date = getMoment('monday', 21, 30, 'Europe/London');
       const expectedClosingDateTime = moment(date);
       expect(openingTimes.nextClosed(date).format()).to.equal(expectedClosingDateTime.format());
     });
     it('should handle closing time of midnight', () => {
+      /* eslint-disable quote-props, quotes, comma-dangle */
       const openingTimesJson = {
-        monday: {
-          times: [
-            { fromTime: '09:00', toTime: '17:30' },
-            { fromTime: '18:30', toTime: '00:00' },
-          ],
-        },
+        "monday": [
+          {
+            "opens": "09:00",
+            "closes": "17:30"
+          },
+          {
+            "opens": "18:30",
+            "closes": "00:00"
+          }
+        ]
       };
+      /* eslint-enable quote-props, quotes, comma-dangle */
       const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
       const date = getMoment('monday', 21, 30, 'Europe/London');
       const expectedClosingDateTime = getMoment('tuesday', 0, 0, 'Europe/London');
       expect(openingTimes.nextClosed(date).format()).to.equal(expectedClosingDateTime.format());
     });
     it('should handle closing time of after midnight', () => {
+      /* eslint-disable quote-props, quotes, comma-dangle */
       const openingTimesJson = {
-        monday: {
-          times: [
-            { fromTime: '09:00', toTime: '17:30' },
-            { fromTime: '18:30', toTime: '01:00' },
-          ],
-        },
+        "monday": [
+          { "opens": "09:00", "closes": "17:30" },
+          { "opens": "18:30", "closes": "01:00" }
+        ]
       };
+      /* eslint-enable quote-props, quotes, comma-dangle */
       const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
       const date = getMoment('monday', 21, 30, 'Europe/London');
       const expectedClosingDateTime = getMoment('tuesday', 1, 0, 'Europe/London');
@@ -347,27 +326,14 @@ describe('OpeningTimes', () => {
     });
   });
   describe('getOpeningHoursMessage()', () => {
-    const openingTimesJson = {
-      monday: {
-        times: [
-          { fromTime: '09:00', toTime: '12:30' },
-          { fromTime: '13:30', toTime: '17:30' },
-          { fromTime: '18:30', toTime: '00:00' },
-        ],
-      },
-      tuesday: {
-        times: [
-          { fromTime: '09:00', toTime: '12:30' },
-          { fromTime: '13:30', toTime: '17:30' },
-        ],
-      },
-      wednesday: {
-        times: [
-          { fromTime: '09:00', toTime: '12:30' },
-          { fromTime: '13:30', toTime: '17:30' },
-        ],
-      },
-    };
+    const openingTimesJson = getRegularWorkingWeekWithLunchBreaks();
+    /* eslint-disable quote-props, quotes, comma-dangle */
+    openingTimesJson.monday = [
+      { "opens": "09:00", "closes": "12:30" },
+      { "opens": "13:30", "closes": "17:30" },
+      { "opens": "18:30", "closes": "00:00" }
+    ];
+    /* eslint-enable quote-props, quotes, comma-dangle */
     const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
     it('when currently open should return open message', () => {
       const date = getMoment('monday', 13, 30, 'Europe/London');
@@ -432,43 +398,28 @@ describe('OpeningTimes', () => {
       expect(formattedOpeningTimes.monday.times[2].toTime).to.equal('midnight');
     });
     it('times should be returned as am/pm', () => {
-      const openingTimesJson = {
-        monday: {
-          times: [
-            { fromTime: '09:00', toTime: '12:30' },
-            { fromTime: '13:30', toTime: '17:30' },
-            { fromTime: '18:30', toTime: '00:00' },
-          ],
-        },
-        tuesday: { times: ['Closed'] },
-        wednesday: { times: ['Closed'] },
-        thursday: { times: ['Closed'] },
-        friday: { times: ['Closed'] },
-        saturday: { times: ['Closed'] },
-        sunday: { times: ['Closed'] },
-      };
+      const openingTimesJson = getRegularWorkingWeekWithLunchBreaks();
+      /* eslint-disable quote-props, quotes, comma-dangle */
+      openingTimesJson.monday = [
+        { "opens": "09:00", "closes": "12:30" },
+        { "opens": "13:30", "closes": "17:30" },
+        { "opens": "18:30", "closes": "00:00" }
+      ];
+      /* eslint-enable quote-props, quotes, comma-dangle */
       const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
       const formattedOpeningTimes = openingTimes.getFormattedOpeningTimes();
-      expect(formattedOpeningTimes.monday.times[0].fromTime).to.equal('9:00 am');
-      expect(formattedOpeningTimes.monday.times[0].toTime).to.equal('12:30 pm');
-      expect(formattedOpeningTimes.monday.times[1].fromTime).to.equal('1:30 pm');
-      expect(formattedOpeningTimes.monday.times[1].toTime).to.equal('5:30 pm');
-      expect(formattedOpeningTimes.monday.times[2].fromTime).to.equal('6:30 pm');
-      expect(formattedOpeningTimes.monday.times[2].toTime).to.equal('midnight');
+      expect(formattedOpeningTimes.monday[0].opens).to.equal('9:00 am');
+      expect(formattedOpeningTimes.monday[0].closes).to.equal('12:30 pm');
+      expect(formattedOpeningTimes.monday[1].opens).to.equal('1:30 pm');
+      expect(formattedOpeningTimes.monday[1].closes).to.equal('5:30 pm');
+      expect(formattedOpeningTimes.monday[2].opens).to.equal('6:30 pm');
+      expect(formattedOpeningTimes.monday[2].closes).to.equal('midnight');
     });
     it('should handle closed all week', () => {
-      const openingTimesJson = {
-        monday: { times: ['Closed'] },
-        tuesday: { times: ['Closed'] },
-        wednesday: { times: ['Closed'] },
-        thursday: { times: ['Closed'] },
-        friday: { times: ['Closed'] },
-        saturday: { times: ['Closed'] },
-        sunday: { times: ['Closed'] },
-      };
+      const openingTimesJson = getClosedAllWeek();
       const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
       const formattedOpeningTimes = openingTimes.getFormattedOpeningTimes();
-      expect(formattedOpeningTimes.monday.times[0]).to.equal('Closed');
+      expect(formattedOpeningTimes.monday.length).to.equal(0);
     });
   });
 });

--- a/test/OpeningTimes.js
+++ b/test/OpeningTimes.js
@@ -316,20 +316,16 @@ describe('OpeningTimes', () => {
         expect(openingTimes.getOpeningHoursMessage(date)).to.equal('Open until midnight');
       });
     });
-    it('when closed all week the should return unknown opening time message', () => {
-      const closedTimesJson = {
-        monday: { times: ['Closed'] },
-        tuesday: { times: ['Closed'] },
-        wednesday: { times: ['Closed'] },
-        thursday: { times: ['Closed'] },
-        friday: { times: ['Closed'] },
-        saturday: { times: ['Closed'] },
-        sunday: { times: ['Closed'] },
-      };
-      const date = getMoment('monday', 8, 30, 'Europe/London');
-      const closedTimes = new OpeningTimes(closedTimesJson, 'Europe/London');
-      expect(closedTimes.getOpeningHoursMessage(date))
-        .to.equal('The next opening time is unknown.');
+    describe('closed all week', () => {
+      const openingTimesJson = getClosedAllWeek();
+      const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
+      const date = getMoment('monday', 19, 30, 'Europe/London');
+
+      it('should return a message asking to call for times', () => {
+        const message = openingTimes.getOpeningHoursMessage(date);
+
+        expect(message).to.be.equal('Call for opening times.');
+      });
     });
   });
   describe('formatOpeningTimes()', () => {

--- a/test/OpeningTimes.js
+++ b/test/OpeningTimes.js
@@ -351,38 +351,25 @@ describe('OpeningTimes', () => {
     });
   });
   describe('formatOpeningTimes()', () => {
-    it('times should be returned as two digit 24 hour', () => {
-      const openingTimesJson = {
-        monday: {
-          times: [
-            { fromTime: '09:00', toTime: '12:30' },
-            { fromTime: '13:30', toTime: '17:30' },
-            { fromTime: '18:30', toTime: '00:00' },
-          ],
-        },
-        tuesday: { times: ['Closed'] },
-        wednesday: { times: ['Closed'] },
-        thursday: { times: ['Closed'] },
-        friday: { times: ['Closed'] },
-        saturday: { times: ['Closed'] },
-        sunday: { times: ['Closed'] },
-      };
+    it('when passed the format string \'HH:mm\' times should be returned in that format', () => {
+      const openingTimesJson = getRegularWorkingWeekWithCustomSession(
+      [{ opens: '09:00', closes: '12:30' },
+       { opens: '13:30', closes: '17:30' },
+       { opens: '18:30', closes: '00:00' }]);
       const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
       const formattedOpeningTimes = openingTimes.getFormattedOpeningTimes('HH:mm');
-      expect(formattedOpeningTimes.monday.times[0].fromTime).to.equal('09:00');
-      expect(formattedOpeningTimes.monday.times[0].toTime).to.equal('12:30');
-      expect(formattedOpeningTimes.monday.times[1].fromTime).to.equal('13:30');
-      expect(formattedOpeningTimes.monday.times[1].toTime).to.equal('17:30');
-      expect(formattedOpeningTimes.monday.times[2].fromTime).to.equal('18:30');
-      expect(formattedOpeningTimes.monday.times[2].toTime).to.equal('midnight');
+      expect(formattedOpeningTimes.monday[0].opens).to.equal('09:00');
+      expect(formattedOpeningTimes.monday[0].closes).to.equal('12:30');
+      expect(formattedOpeningTimes.monday[1].opens).to.equal('13:30');
+      expect(formattedOpeningTimes.monday[1].closes).to.equal('17:30');
+      expect(formattedOpeningTimes.monday[2].opens).to.equal('18:30');
+      expect(formattedOpeningTimes.monday[2].closes).to.equal('midnight');
     });
-    it('times should be returned as am/pm', () => {
-      const openingTimesJson = getRegularWorkingWeekWithLunchBreaks();
-      openingTimesJson.monday = [
-        { opens: '09:00', closes: '12:30' },
-        { opens: '13:30', closes: '17:30' },
-        { opens: '18:30', closes: '00:00' },
-      ];
+    it('by default times should be returned as am/pm', () => {
+      const openingTimesJson = getRegularWorkingWeekWithCustomSession(
+      [{ opens: '09:00', closes: '12:30' },
+       { opens: '13:30', closes: '17:30' },
+       { opens: '18:30', closes: '00:00' }]);
       const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
       const formattedOpeningTimes = openingTimes.getFormattedOpeningTimes();
       expect(formattedOpeningTimes.monday[0].opens).to.equal('9:00 am');

--- a/test/OpeningTimes.js
+++ b/test/OpeningTimes.js
@@ -1,4 +1,5 @@
 const chai = require('chai');
+const AssertionError = require('assert').AssertionError;
 const OpeningTimes = require('../OpeningTimes');
 const moment = require('moment');
 require('moment-timezone');
@@ -85,25 +86,46 @@ function getRegularWorkingWeekWithCustomSession(session) {
 
 describe('OpeningTimes', () => {
   describe('constructor', () => {
-    it('should not throw for valid parameters', () => {
-      const openingTimesJson = {};
-      expect(() => new OpeningTimes(openingTimesJson, 'Europe/London')).to.not.throw();
+    /* eslint-disable no-new, max-len */
+    describe('should validate parameters', () => {
+      it('opening times should be defined', () => {
+        expect(() => { new OpeningTimes(); })
+          .to.throw(
+            AssertionError,
+            'parameter \'openingTimes\' undefined/empty');
+      });
+      it('opening times should cover all days of the week', () => {
+        const openingTimesJson = getRegularWorkingWeek();
+        delete openingTimesJson.monday;
+        expect(() => { new OpeningTimes(openingTimesJson); })
+          .to.throw(
+            AssertionError,
+            'parameter \'openingTimes\' should have all days of the week (friday,saturday,sunday,thursday,tuesday,wednesday)');
+      });
+      it('opening times should have opening times for each day of the week', () => {
+        const openingTimesJson = getRegularWorkingWeek();
+        openingTimesJson.monday = undefined;
+        expect(() => { new OpeningTimes(openingTimesJson); })
+          .to.throw(
+            AssertionError,
+            'parameter \'openingTimes\' should define opening times for each day. ({ sunday: [],\n  monday: undefined,\n  tuesday: [ { opens: \'09:00\', closes: \'17:30\' } ],\n  wednesday: [ { opens: \'09:00\', closes: \'17:30\' } ],\n  thursday: [ { opens: \'09:00\', closes: \'17:30\' } ],\n  friday: [ { opens: \'09:00\', closes: \'17:30\' } ],\n  saturday: [ { opens: \'09:00\', closes: \'17:30\' } ] })');
+      });
+      it('time zone should be defined', () => {
+        const openingTimesJson = getRegularWorkingWeek();
+        expect(() => { new OpeningTimes(openingTimesJson); })
+          .to.throw(
+            AssertionError,
+            'parameter \'timeZone\' undefined/empty');
+      });
+      it('time zone should be valid', () => {
+        const openingTimesJson = getRegularWorkingWeek();
+        expect(() => { new OpeningTimes(openingTimesJson, 'blah'); })
+          .to.throw(
+            AssertionError,
+            'parameter \'timeZone\' not a valid timezone');
+      });
     });
-    it('should assert opening times parameter is not missing', () => {
-      expect(() => new OpeningTimes())
-        .to.throw('AssertionError: parameter \'openingTimes\' undefined/empty');
-    });
-    it('should assert time zone parameter is not missing', () => {
-      const openingTimesJson = {};
-      expect(() => new OpeningTimes(openingTimesJson))
-        .to.throw('AssertionError: parameter \'timeZone\' undefined/empty');
-    });
-    it('should assert time zone is parameter valid', () => {
-      const openingTimesJson = {};
-      expect(() => new OpeningTimes(openingTimesJson, 'Blah/Blah'))
-        .to.throw('AssertionError: parameter \'timeZone\' is not a ' +
-                  'valid TimeZone (Blah/Blah)');
-    });
+    /* eslint-enable no-new, max-len */
   });
   describe('isOpen()', () => {
     describe('single session (9:00 - 17:30)', () => {


### PR DESCRIPTION
Changed format of opening times expected in constructor to be a cleaner object rather than including the leaky abstractions that of the JSON generated from the NHS Choices Syndication XML response.
Add parser and tests for NHS Choices Syndication organisation xml response.
Added validation to OpeningTimes constructor and tests for this
Incremented version to 1.0.0