### PR TITLE
:bug: Provide message when every day is closed

### DIFF
--- a/OpeningTimes.js
+++ b/OpeningTimes.js
@@ -170,6 +170,9 @@ class OpeningTimes {
         `Open until ${closedTime} ${closedDay}`);
     }
     const openNext = this.nextOpen(datetime);
+    if (!openNext) {
+      return 'Call for opening times.';
+    }
     const timeUntilOpen = openNext.diff(datetime, 'minutes');
     const openDay = openNext.calendar(datetime, {
       sameDay: '[today]',

--- a/test/OpeningTimes.js
+++ b/test/OpeningTimes.js
@@ -295,6 +295,17 @@ describe('OpeningTimes', () => {
         expect(openingTimes.getOpeningHoursMessage(date)).to.equal('Open until midnight');
       });
     });
+    describe('closed all week', () => {
+      const openingTimesJson = getClosedAllWeek();
+      const openingTimes = new OpeningTimes(openingTimesJson, 'Europe/London');
+      const date = getMoment('monday', 19, 30, 'Europe/London');
+
+      it('should return a message asking to call for times', () => {
+        const message = openingTimes.getOpeningHoursMessage(date);
+
+        expect(message).to.be.equal('Call for opening times.');
+      });
+    });
   });
   describe('formatOpeningTimes()', () => {
     it('when passed the format string \'HH:mm\' times should be returned in that format', () => {


### PR DESCRIPTION
Ignoring the question of where the responsibility lies for generating the message based on the opening times. This change fix an issue that manifested itself when all of the days were closed. Previously an exception was thrown `TypeError: Cannot read property 'diff' of undefined` from line 173.