### PR TITLE
Work on the repo's githooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
   "license": "MIT",
   "config": {
     "ghooks": {
-      "pre-commit":    "git stash --keep-index && npm run lint && npm run test && git stash pop",
-      "post-rewrite":  "git stash --keep-index && npm run lint && npm run test && git stash pop",
+      "pre-commit": "git stash --keep-index && npm run lint && npm run test && git stash pop",
       "post-checkout": "npm install"
     }
   }

--- a/package.json
+++ b/package.json
@@ -48,8 +48,9 @@
   "license": "MIT",
   "config": {
     "ghooks": {
-      "pre-commit": "npm run lint && npm run test",
-      "post-rewrite": "npm run lint && npm run test"
+      "pre-commit":    "git stash --keep-index -q && npm run lint && npm run test && git stash pop -q",
+      "post-rewrite":  "git stash --keep-index -q && npm run lint && npm run test && git stash pop -q",
+      "post-checkout": "npm install"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
   "license": "MIT",
   "config": {
     "ghooks": {
-      "pre-commit":    "git stash --keep-index -q && npm run lint && npm run test && git stash pop -q",
-      "post-rewrite":  "git stash --keep-index -q && npm run lint && npm run test && git stash pop -q",
+      "pre-commit":    "git stash --keep-index && npm run lint && npm run test && git stash pop",
+      "post-rewrite":  "git stash --keep-index && npm run lint && npm run test && git stash pop",
       "post-checkout": "npm install"
     }
   }

--- a/test/timings.js
+++ b/test/timings.js
@@ -26,6 +26,7 @@ describe('timings', function test() {
         }
       });
     });
+
     it('including alterations', () => {
       orgs.forEach((o) => {
         if (o.openingTimes) {


### PR DESCRIPTION
Wanted to resolve the problem of tests/lint being run against unstaged files causing the tests/lint to pass locally but not in CI.

I no longer think we need the post-write hook as the problem we were encountering with failing builds, which we attributed to commit amends, was probably to do with that described above. This means the tests won't run twice on commit.

Hook now stashes and un-stashes un-staged changes before and after the test/lint runs.

Also added a post-checkout hook for npm install as I keep forgetting to do that.

The commits around adding/removing spaces were test commits to check the hooks are working and are benign.

If these changes look good then we can apply them to connecting-to-services.