### PR TITLE
Feature/remove past alterations

### DIFF
--- a/OpeningTimes.js
+++ b/OpeningTimes.js
@@ -70,7 +70,7 @@ class OpeningTimes {
   }
 
   _getOpeningTimesForDate(moment) {
-    const alterations = removePastAlterations(this._alterations, moment);
+    const alterations = removePastAlterations(this._alterations, moment, this._timeZone);
     if (alterations) {
       // TODO: decide what to do if there is only >1 match
       const alterationMatch =

--- a/OpeningTimes.js
+++ b/OpeningTimes.js
@@ -64,7 +64,7 @@ class OpeningTimes {
     if (timeString === '00:00' || timeString === '23:59') {
       return 'midnight';
     }
-    const aDate = new Moment('2016-07-25T00:00:00+01:00');
+    const aDate = Moment('2016-07-25T00:00:00+01:00');
     const time = this._getTimeFromString(timeString);
     return this._getTime(aDate, time.hours, time.minutes).format(formatString);
   }
@@ -75,7 +75,7 @@ class OpeningTimes {
       // TODO: decide what to do if there is only >1 match
       const alterationMatch =
         Object.keys(alterations)
-          .filter(a => new Moment(a).tz(this._timeZone).isSame(moment, 'day'))[0];
+          .filter(a => Moment(a).tz(this._timeZone).isSame(moment, 'day'))[0];
       return alterationMatch ?
         alterations[alterationMatch] :
         this._openingTimes[this._getDayName(moment)];

--- a/OpeningTimes.js
+++ b/OpeningTimes.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const util = require('util');
 const Moment = require('moment');
-const removePastAlterations = require('./src/lib/utils').removePastAlterations;
+const removePastAlterations = require('./src/lib/removePastAlterations');
 require('moment-timezone');
 
 const weekdays = require('moment').weekdays().map(d => d.toLowerCase());
@@ -22,7 +22,7 @@ class OpeningTimes {
     assert(Moment.tz.zone(timeZone), 'parameter \'timeZone\' not a valid timezone');
     this._openingTimes = openingTimes;
     this._timeZone = timeZone;
-    this._alterations = removePastAlterations(alterations);
+    this._alterations = alterations;
   }
 
   /* Private methods - you could use them but they  are not part of the API
@@ -70,13 +70,14 @@ class OpeningTimes {
   }
 
   _getOpeningTimesForDate(moment) {
-    if (this._alterations) {
+    const alterations = removePastAlterations(this._alterations, moment);
+    if (alterations) {
       // TODO: decide what to do if there is only >1 match
       const alterationMatch =
-        Object.keys(this._alterations)
+        Object.keys(alterations)
           .filter(a => new Moment(a).tz(this._timeZone).isSame(moment, 'day'))[0];
       return alterationMatch ?
-        this._alterations[alterationMatch] :
+        alterations[alterationMatch] :
         this._openingTimes[this._getDayName(moment)];
     }
     return this._openingTimes[this._getDayName(moment)];

--- a/OpeningTimes.js
+++ b/OpeningTimes.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const util = require('util');
 const Moment = require('moment');
+const removePastAlterations = require('./src/lib/utils').removePastAlterations;
 require('moment-timezone');
 
 const weekdays = require('moment').weekdays().map(d => d.toLowerCase());
@@ -21,7 +22,7 @@ class OpeningTimes {
     assert(Moment.tz.zone(timeZone), 'parameter \'timeZone\' not a valid timezone');
     this._openingTimes = openingTimes;
     this._timeZone = timeZone;
-    this._alterations = alterations;
+    this._alterations = removePastAlterations(alterations);
   }
 
   /* Private methods - you could use them but they  are not part of the API

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moment-opening-times",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A small class to determine the status of a given moment in relation to a set of opening times",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -40,11 +40,11 @@
     "coverage-generate": "istanbul cover _mocha -- --recursive test",
     "coverage-upload": "cat ./coverage/lcov.info | coveralls",
     "git-hook": "yarn lint && yarn coverage-generate && yarn coverage-check",
-    "lint": "eslint --ext .js,.json --max-warnings 0 .",
+    "lint": "eslint --ext .js --max-warnings 0 .",
     "precommit": "yarn git-hook",
     "prepublish": "yarn git-hook",
     "prepush": "yarn git-hook && yarn snyk test",
-    "test": "TZ=GMT mocha",
+    "test": "TZ=GMT mocha --recursive test/unit",
     "test-ci": "yarn git-hook && yarn coverage-upload",
     "test-watch": "yarn test -- --watch --reporter min"
   },

--- a/src/lib/removePastAlterations.js
+++ b/src/lib/removePastAlterations.js
@@ -1,7 +1,8 @@
-function removePastAlterations(alterations, moment) {
-  if (alterations) {
-    const todayInKeyFormat = moment.format('YYYY-MM-DD');
+const Moment = require('moment');
 
+function removePastAlterations(alterations, moment, timeZone) {
+  if (alterations) {
+    const todayInKeyFormat = Moment.tz(moment, timeZone).format('YYYY-MM-DD');
     const presentAndFutureAlterations = {};
     const alterationsKeys = Object.keys(alterations);
 

--- a/src/lib/removePastAlterations.js
+++ b/src/lib/removePastAlterations.js
@@ -1,9 +1,7 @@
-const moment = require('moment');
-
-const todayInKeyFormat = moment().format('YYYY-MM-DD');
-
-function removePastAlterations(alterations) {
+function removePastAlterations(alterations, moment) {
   if (alterations) {
+    const todayInKeyFormat = moment.format('YYYY-MM-DD');
+
     const presentAndFutureAlterations = {};
     const alterationsKeys = Object.keys(alterations);
 
@@ -17,6 +15,4 @@ function removePastAlterations(alterations) {
   return alterations;
 }
 
-module.exports = {
-  removePastAlterations,
-};
+module.exports = removePastAlterations;

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,0 +1,22 @@
+const moment = require('moment');
+
+const todayInKeyFormat = moment().format('YYYY-MM-DD');
+
+function removePastAlterations(alterations) {
+  if (alterations) {
+    const presentAndFutureAlterations = {};
+    const alterationsKeys = Object.keys(alterations);
+
+    alterationsKeys.forEach((key) => {
+      if (key >= todayInKeyFormat) {
+        presentAndFutureAlterations[key] = alterations[key];
+      }
+    });
+    return presentAndFutureAlterations;
+  }
+  return alterations;
+}
+
+module.exports = {
+  removePastAlterations,
+};

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -1,0 +1,39 @@
+const moment = require('moment');
+
+const alterationDateKeyFormat = 'YYYY-MM-DD';
+
+function alterations(daysToChange) {
+  const dateString = moment().add(daysToChange, 'day').format(alterationDateKeyFormat);
+
+  const returnValue = {};
+  returnValue[dateString] = [];
+  return returnValue;
+}
+
+function alterationsPast() {
+  return alterations(-1);
+}
+
+function alterationsPresent() {
+  return alterations(0);
+}
+
+function alterationsFuture() {
+  return alterations(1);
+}
+
+function alterationsPresentAndFuture() {
+  return Object.assign({}, alterationsPresent(), alterationsFuture());
+}
+
+function alterationsPastPresentAndFuture() {
+  return Object.assign({}, alterationsPast(), alterationsPresent(), alterationsFuture());
+}
+
+module.exports = {
+  alterationsPast,
+  alterationsPresent,
+  alterationsFuture,
+  alterationsPresentAndFuture,
+  alterationsPastPresentAndFuture,
+};

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -1,33 +1,35 @@
-const moment = require('moment');
-
 const alterationDateKeyFormat = 'YYYY-MM-DD';
 
-function alterations(daysToChange) {
-  const dateString = moment().add(daysToChange, 'day').format(alterationDateKeyFormat);
+// eslint-disable-next-line no-underscore-dangle
+function _alterations(moment, daysToChange) {
+  const dateString = moment.clone().add(daysToChange, 'day').format(alterationDateKeyFormat);
 
   const returnValue = {};
   returnValue[dateString] = [];
   return returnValue;
 }
 
-function alterationsPast() {
-  return alterations(-1);
+function alterationsPast(moment) {
+  return _alterations(moment, -1);
 }
 
-function alterationsPresent() {
-  return alterations(0);
+function alterationsPresent(moment) {
+  return _alterations(moment, 0);
 }
 
-function alterationsFuture() {
-  return alterations(1);
+function alterationsFuture(moment) {
+  return _alterations(moment, 1);
 }
 
-function alterationsPresentAndFuture() {
-  return Object.assign({}, alterationsPresent(), alterationsFuture());
+function alterationsPresentAndFuture(moment) {
+  return Object.assign({}, alterationsPresent(moment), alterationsFuture(moment));
 }
 
-function alterationsPastPresentAndFuture() {
-  return Object.assign({}, alterationsPast(), alterationsPresent(), alterationsFuture());
+function alterationsPastPresentAndFuture(moment) {
+  return Object.assign({},
+    alterationsPast(moment),
+    alterationsPresent(moment),
+    alterationsFuture(moment));
 }
 
 module.exports = {

--- a/test/performance/timings.js
+++ b/test/performance/timings.js
@@ -1,7 +1,7 @@
 const orgLimit = 1000;
 
-const OpeningTimes = require('../OpeningTimes');
-const orgs = require('./pharmacy-list').slice(0, orgLimit);
+const OpeningTimes = require('../../OpeningTimes');
+const orgs = require('../resources/pharmacy-list').slice(0, orgLimit);
 const Moment = require('moment');
 
 const timeZone = 'Europe/London';

--- a/test/performance/timings.js
+++ b/test/performance/timings.js
@@ -22,7 +22,7 @@ describe('timings', function test() {
           const openingTimes =
             new OpeningTimes(o.openingTimes.general, timeZone);
           openingTimes.getStatus(
-            new Moment('2016-11-05T11:00:00').tz(timeZone), { next: true });
+            Moment('2016-11-05T11:00:00').tz(timeZone), { next: true });
         }
       });
     });
@@ -33,7 +33,7 @@ describe('timings', function test() {
           const openingTimes =
             new OpeningTimes(o.openingTimes.general, timeZone, o.openingTimes.alterations);
           openingTimes.getStatus(
-            new Moment('2016-11-05T11:00:00').tz(timeZone), { next: true });
+            Moment('2016-11-05T11:00:00').tz(timeZone), { next: true });
         }
       });
     });

--- a/test/unit/OpeningTimes.js
+++ b/test/unit/OpeningTimes.js
@@ -6,7 +6,7 @@ const Moment = require('moment');
 require('moment-timezone');
 
 const expect = chai.expect;
-const aSunday = new Moment('2016-07-24T00:00:00+00:00');
+const aSunday = Moment('2016-07-24T00:00:00+00:00');
 
 chai.use(chaiMoment);
 chaiMoment.setErrorFormat('LLLL');
@@ -16,7 +16,7 @@ function getMoment(day, hours, minutes, timeZone) {
     .weekdays()
     .map(d => d.toLowerCase())
     .indexOf(day);
-  const moment = new Moment(aSunday).tz(timeZone);
+  const moment = Moment(aSunday).tz(timeZone);
   moment.add(dayNumber, 'days').hours(hours).minutes(minutes);
   return moment;
 }
@@ -413,7 +413,7 @@ describe('OpeningTimes', () => {
         });
         it('nextOpen should be start of mondays morning session', () => {
           const expectedOpeningDateTime =
-            new Moment(moment)
+            Moment(moment)
               .add(3, 'days')
               .hours(9)
               .minutes(0);
@@ -547,7 +547,7 @@ describe('OpeningTimes', () => {
           '2016-01-01': [],
           '2016-08-29': [],
         };
-        const moment = new Moment('2016-08-29T10:55:00+01:00');
+        const moment = Moment('2016-08-29T10:55:00+01:00');
         const openingTimes = getNewOpeningTimes(openingTimesJson, timeZone, alterations);
         const status =
           openingTimes.getStatus(moment, { next: true });
@@ -555,7 +555,7 @@ describe('OpeningTimes', () => {
           expect(status.isOpen).to.equal(false);
         });
         it('nextOpen should be start of tomorrows session', () => {
-          momentsShouldBeSame(status.nextOpen, new Moment('2016-08-30T09:00:00+01:00'));
+          momentsShouldBeSame(status.nextOpen, Moment('2016-08-30T09:00:00+01:00'));
         });
         it('nextClosed should be passed moment', () => {
           momentsShouldBeSame(status.nextClosed, moment);
@@ -572,13 +572,13 @@ describe('OpeningTimes', () => {
         const openingTimes = getNewOpeningTimes(openingTimesJson, timeZone, alterations);
 
         describe('moment during the alteration', () => {
-          const moment = new Moment('2016-08-29T12:30:00+01:00');
+          const moment = Moment('2016-08-29T12:30:00+01:00');
           const status = openingTimes.getStatus(moment, { next: true });
           it('isOpen should be true', () => {
             expect(status.isOpen).to.equal(true);
           });
           it('nextClosed should be end of afternoon session', () => {
-            momentsShouldBeSame(status.nextClosed, new Moment('2016-08-29T16:30:00+01:00'));
+            momentsShouldBeSame(status.nextClosed, Moment('2016-08-29T16:30:00+01:00'));
           });
           it('nextOpen should be passed moment', () => {
             momentsShouldBeSame(status.nextOpen, moment);
@@ -586,13 +586,13 @@ describe('OpeningTimes', () => {
         });
 
         describe('moment after the alteration', () => {
-          const moment = new Moment('2016-08-29T16:35:00+01:00');
+          const moment = Moment('2016-08-29T16:35:00+01:00');
           const status = openingTimes.getStatus(moment, { next: true });
           it('isOpen should be false', () => {
             expect(status.isOpen).to.equal(false);
           });
           it('nextOpen should be the start of tomorrows morning session', () => {
-            momentsShouldBeSame(status.nextOpen, new Moment('2016-08-30T09:00:00+01:00'));
+            momentsShouldBeSame(status.nextOpen, Moment('2016-08-30T09:00:00+01:00'));
           });
           it('nextClosed should be passed moment', () => {
             momentsShouldBeSame(status.nextClosed, moment);
@@ -600,13 +600,13 @@ describe('OpeningTimes', () => {
         });
 
         describe('moment before the alteration', () => {
-          const moment = new Moment('2016-08-29T10:55:00+01:00');
+          const moment = Moment('2016-08-29T10:55:00+01:00');
           const status = openingTimes.getStatus(moment, { next: true });
           it('isOpen should be false', () => {
             expect(status.isOpen).to.equal(false);
           });
           it('nextOpen should be the start of the morning session', () => {
-            momentsShouldBeSame(status.nextOpen, new Moment('2016-08-29T11:00:00+01:00'));
+            momentsShouldBeSame(status.nextOpen, Moment('2016-08-29T11:00:00+01:00'));
           });
           it('nextClosed should be passed moment', () => {
             momentsShouldBeSame(status.nextClosed, moment);
@@ -624,13 +624,13 @@ describe('OpeningTimes', () => {
         const openingTimes = getNewOpeningTimes(openingTimesJson, timeZone, alterations);
 
         describe('moment before midnight and during the alteration', () => {
-          const moment = new Moment('2016-08-29T11:30:00+01:00');
+          const moment = Moment('2016-08-29T11:30:00+01:00');
           const status = openingTimes.getStatus(moment, { next: true });
           it('isOpen should be true', () => {
             expect(status.isOpen).to.equal(true);
           });
           it('nextClosed should be end of session', () => {
-            momentsShouldBeSame(status.nextClosed, new Moment('2016-08-30T01:30:00+01:00'));
+            momentsShouldBeSame(status.nextClosed, Moment('2016-08-30T01:30:00+01:00'));
           });
           it('nextOpen should be passed moment', () => {
             momentsShouldBeSame(status.nextOpen, moment);
@@ -638,13 +638,13 @@ describe('OpeningTimes', () => {
         });
 
         describe('moment after midnight and during the alteration', () => {
-          const moment = new Moment('2016-08-30T01:25:00+01:00');
+          const moment = Moment('2016-08-30T01:25:00+01:00');
           const status = openingTimes.getStatus(moment, { next: true });
           it('isOpen should be true', () => {
             expect(status.isOpen).to.equal(true);
           });
           it('nextClosed should be end of session', () => {
-            momentsShouldBeSame(status.nextClosed, new Moment('2016-08-30T01:30:00+01:00'));
+            momentsShouldBeSame(status.nextClosed, Moment('2016-08-30T01:30:00+01:00'));
           });
           it('nextOpen should be passed moment', () => {
             momentsShouldBeSame(status.nextOpen, moment);
@@ -652,13 +652,13 @@ describe('OpeningTimes', () => {
         });
 
         describe('moment after midnight and after the alteration', () => {
-          const moment = new Moment('2016-08-30T01:35:00+01:00');
+          const moment = Moment('2016-08-30T01:35:00+01:00');
           const status = openingTimes.getStatus(moment, { next: true });
           it('isOpen should be false', () => {
             expect(status.isOpen).to.equal(false);
           });
           it('nextOpen should be start of tomorrows session', () => {
-            momentsShouldBeSame(status.nextOpen, new Moment('2016-08-30T09:00:00+01:00'));
+            momentsShouldBeSame(status.nextOpen, Moment('2016-08-30T09:00:00+01:00'));
           });
           it('nextClosed should be passed moment', () => {
             momentsShouldBeSame(status.nextClosed, moment);

--- a/test/unit/OpeningTimes.js
+++ b/test/unit/OpeningTimes.js
@@ -1,7 +1,7 @@
 const chai = require('chai');
 const chaiMoment = require('chai-moment');
 const AssertionError = require('assert').AssertionError;
-const OpeningTimes = require('../OpeningTimes');
+const OpeningTimes = require('../../OpeningTimes');
 const Moment = require('moment');
 require('moment-timezone');
 

--- a/test/unit/lib/removePastAlterations.js
+++ b/test/unit/lib/removePastAlterations.js
@@ -1,45 +1,47 @@
 const chai = require('chai');
-const utils = require('../../../src/lib/utils');
+const moment = require('moment');
+const removePastAlterations = require('../../../src/lib/removePastAlterations');
 const testUtils = require('../../lib/utils');
 
 const expect = chai.expect;
+const now = moment();
 
 describe('Utils', () => {
   describe('removePastAlterations', () => {
     it('should not break when alterations is undefined', () => {
-      utils.removePastAlterations();
+      removePastAlterations();
     });
 
     it('should remove alterations in the past', () => {
-      const alterationsPast = testUtils.alterationsPast();
+      const alterationsPast = testUtils.alterationsPast(now);
 
-      const strippedAlterations = utils.removePastAlterations(alterationsPast);
+      const strippedAlterations = removePastAlterations(alterationsPast, now);
 
       // eslint-disable-next-line no-unused-expressions
       expect(strippedAlterations).to.be.empty;
     });
 
     it('should not remove alterations in the future', () => {
-      const alterationsFuture = testUtils.alterationsFuture();
+      const alterationsFuture = testUtils.alterationsFuture(now);
 
-      const strippedAlterations = utils.removePastAlterations(alterationsFuture);
+      const strippedAlterations = removePastAlterations(alterationsFuture, now);
 
       expect(strippedAlterations).to.be.eql(alterationsFuture);
     });
 
     it('should not remove alterations for present', () => {
-      const alterationsPresent = testUtils.alterationsPresent();
+      const alterationsPresent = testUtils.alterationsPresent(now);
 
-      const strippedAlterations = utils.removePastAlterations(alterationsPresent);
+      const strippedAlterations = removePastAlterations(alterationsPresent, now);
 
       expect(strippedAlterations).to.be.eql(alterationsPresent);
     });
 
     it('should remove alterations in the past and leave them for the present and the future', () => {
-      const alterationsPastPresentAndFuture = testUtils.alterationsPastPresentAndFuture();
-      const alterationsPresentAndFuture = testUtils.alterationsPresentAndFuture();
+      const alterationsPastPresentAndFuture = testUtils.alterationsPastPresentAndFuture(now);
+      const alterationsPresentAndFuture = testUtils.alterationsPresentAndFuture(now);
 
-      const strippedAlterations = utils.removePastAlterations(alterationsPastPresentAndFuture);
+      const strippedAlterations = removePastAlterations(alterationsPastPresentAndFuture, now);
 
       expect(strippedAlterations).to.be.eql(alterationsPresentAndFuture);
     });

--- a/test/unit/lib/removePastAlterations.js
+++ b/test/unit/lib/removePastAlterations.js
@@ -4,6 +4,7 @@ const removePastAlterations = require('../../../src/lib/removePastAlterations');
 const testUtils = require('../../lib/utils');
 
 const expect = chai.expect;
+const timeZone = 'Europe/London';
 const now = moment();
 
 describe('Utils', () => {
@@ -15,7 +16,7 @@ describe('Utils', () => {
     it('should remove alterations in the past', () => {
       const alterationsPast = testUtils.alterationsPast(now);
 
-      const strippedAlterations = removePastAlterations(alterationsPast, now);
+      const strippedAlterations = removePastAlterations(alterationsPast, now, timeZone);
 
       // eslint-disable-next-line no-unused-expressions
       expect(strippedAlterations).to.be.empty;
@@ -24,7 +25,7 @@ describe('Utils', () => {
     it('should not remove alterations in the future', () => {
       const alterationsFuture = testUtils.alterationsFuture(now);
 
-      const strippedAlterations = removePastAlterations(alterationsFuture, now);
+      const strippedAlterations = removePastAlterations(alterationsFuture, now, timeZone);
 
       expect(strippedAlterations).to.be.eql(alterationsFuture);
     });
@@ -32,7 +33,7 @@ describe('Utils', () => {
     it('should not remove alterations for present', () => {
       const alterationsPresent = testUtils.alterationsPresent(now);
 
-      const strippedAlterations = removePastAlterations(alterationsPresent, now);
+      const strippedAlterations = removePastAlterations(alterationsPresent, now, timeZone);
 
       expect(strippedAlterations).to.be.eql(alterationsPresent);
     });
@@ -41,7 +42,8 @@ describe('Utils', () => {
       const alterationsPastPresentAndFuture = testUtils.alterationsPastPresentAndFuture(now);
       const alterationsPresentAndFuture = testUtils.alterationsPresentAndFuture(now);
 
-      const strippedAlterations = removePastAlterations(alterationsPastPresentAndFuture, now);
+      const strippedAlterations =
+        removePastAlterations(alterationsPastPresentAndFuture, now, timeZone);
 
       expect(strippedAlterations).to.be.eql(alterationsPresentAndFuture);
     });

--- a/test/unit/lib/utils.js
+++ b/test/unit/lib/utils.js
@@ -1,0 +1,47 @@
+const chai = require('chai');
+const utils = require('../../../src/lib/utils');
+const testUtils = require('../../lib/utils');
+
+const expect = chai.expect;
+
+describe('Utils', () => {
+  describe('removePastAlterations', () => {
+    it('should not break when alterations is undefined', () => {
+      utils.removePastAlterations();
+    });
+
+    it('should remove alterations in the past', () => {
+      const alterationsPast = testUtils.alterationsPast();
+
+      const strippedAlterations = utils.removePastAlterations(alterationsPast);
+
+      // eslint-disable-next-line no-unused-expressions
+      expect(strippedAlterations).to.be.empty;
+    });
+
+    it('should not remove alterations in the future', () => {
+      const alterationsFuture = testUtils.alterationsFuture();
+
+      const strippedAlterations = utils.removePastAlterations(alterationsFuture);
+
+      expect(strippedAlterations).to.be.eql(alterationsFuture);
+    });
+
+    it('should not remove alterations for present', () => {
+      const alterationsPresent = testUtils.alterationsPresent();
+
+      const strippedAlterations = utils.removePastAlterations(alterationsPresent);
+
+      expect(strippedAlterations).to.be.eql(alterationsPresent);
+    });
+
+    it('should remove alterations in the past and leave them for the present and the future', () => {
+      const alterationsPastPresentAndFuture = testUtils.alterationsPastPresentAndFuture();
+      const alterationsPresentAndFuture = testUtils.alterationsPresentAndFuture();
+
+      const strippedAlterations = utils.removePastAlterations(alterationsPastPresentAndFuture);
+
+      expect(strippedAlterations).to.be.eql(alterationsPresentAndFuture);
+    });
+  });
+});


### PR DESCRIPTION
In order to improve the performance of the library I've removed any `alterations` that are in the past. Obviously this can and should also be done at the data level, however, even when that has happened I think having this change is a positive addition.
There is no test for the removal of the past alterations which isn't ideal but trying to test for the lack of something is pretty difficult. The way I know this is a good change from the POV of improving performance is to have run a couple of performance tests on the application with the API having this change and not having the change. The improvements are considerable and amount to approximately an order of magnitude improvement when the time is in the early hours i.e. when most places are closed.