### PR TITLE
Performance tweaks

### DIFF
--- a/OpeningTimes.js
+++ b/OpeningTimes.js
@@ -53,7 +53,7 @@ class OpeningTimes {
 
   _createDateTime(moment, timeString) {
     const time = this._getTimeFromString(timeString);
-    return this._getTime(moment, time.hours, time.minutes).tz(this._timeZone);
+    return this._getTime(moment, time.hours, time.minutes);
   }
 
   _isClosedAllDay(daysOpeningTimes) {
@@ -64,18 +64,18 @@ class OpeningTimes {
     if (timeString === '00:00' || timeString === '23:59') {
       return 'midnight';
     }
-    const aDate = Moment('2016-07-25T00:00:00+01:00');
+    const aDate = Moment(Date.now());
     const time = this._getTimeFromString(timeString);
     return this._getTime(aDate, time.hours, time.minutes).format(formatString);
   }
 
   _getOpeningTimesForDate(moment) {
-    const alterations = removePastAlterations(this._alterations, moment, this._timeZone);
+    const alterations = removePastAlterations(this._alterations, moment);
     if (alterations) {
       // TODO: decide what to do if there is only >1 match
       const alterationMatch =
         Object.keys(alterations)
-          .filter(a => Moment(a).tz(this._timeZone).isSame(moment, 'day'))[0];
+          .filter(a => Moment(a).isSame(moment, 'day'))[0];
       return alterationMatch ?
         alterations[alterationMatch] :
         this._openingTimes[this._getDayName(moment)];
@@ -144,7 +144,7 @@ class OpeningTimes {
 
     if (nextDay) {
       const nextSession = nextDay.find(this._getDateBeforeSessionFinder(moment));
-      return nextSession.from.tz(this._timeZone);
+      return nextSession.from;
     }
 
     return undefined;

--- a/OpeningTimes.js
+++ b/OpeningTimes.js
@@ -34,12 +34,7 @@ class OpeningTimes {
 
   _getTime(moment, hour, minute) {
     const returnDate = moment.clone().tz(this._timeZone);
-    returnDate.set({
-      hour,
-      minute,
-      second: 0,
-      millisecond: 0,
-    });
+    returnDate.startOf('hour').hour(hour).minute(minute);
 
     return returnDate;
   }
@@ -64,7 +59,7 @@ class OpeningTimes {
     if (timeString === '00:00' || timeString === '23:59') {
       return 'midnight';
     }
-    const aDate = Moment(Date.now());
+    const aDate = Moment();
     const time = this._getTimeFromString(timeString);
     return this._getTime(aDate, time.hours, time.minutes).format(formatString);
   }

--- a/OpeningTimes.js
+++ b/OpeningTimes.js
@@ -40,9 +40,10 @@ class OpeningTimes {
   }
 
   _getTimeFromString(timeString) {
+    const timeSplit = timeString.split(':');
     return {
-      hours: parseInt(timeString.split(':')[0], 10),
-      minutes: parseInt(timeString.split(':')[1], 10),
+      hours: parseInt(timeSplit[0], 10),
+      minutes: parseInt(timeSplit[1], 10),
     };
   }
 
@@ -68,21 +69,21 @@ class OpeningTimes {
     const alterations = removePastAlterations(this._alterations, moment);
     if (alterations) {
       // TODO: decide what to do if there is only >1 match
-      const alterationMatch =
-        Object.keys(alterations)
-          .filter(a => Moment(a).isSame(moment, 'day'))[0];
-      return alterationMatch ?
-        alterations[alterationMatch] :
+      const momentDate = moment.format('YYYY-MM-DD');
+      const todaysAlteration = Object.keys(alterations).find(a => a === momentDate);
+
+      return todaysAlteration ?
+        alterations[todaysAlteration] :
         this._openingTimes[this._getDayName(moment)];
     }
     return this._openingTimes[this._getDayName(moment)];
   }
 
   _getOpeningTimesSessionForMoment(moment, daysLookAhead) {
-    let returnValue;
     for (let day = daysLookAhead - 1; day >= -1; day -= 1) {
       const aMoment = moment.clone().add(day, 'day');
       const openingTimes = this._getOpeningTimesForDate(aMoment);
+
       for (let j = 0; j < openingTimes.length; j += 1) {
         const t = openingTimes[j];
         const from = this._createDateTime(aMoment, t.opens);
@@ -93,12 +94,11 @@ class OpeningTimes {
         }
 
         if (moment.isBetween(from, to, null, '[)')) {
-          returnValue = { from, to };
-          return returnValue;
+          return { from, to };
         }
       }
     }
-    return returnValue;
+    return undefined;
   }
 
   _getOpenSessions(moment, days) {
@@ -138,8 +138,7 @@ class OpeningTimes {
       .find(day => (day.some(this._getDateBeforeSessionFinder(moment))));
 
     if (nextDay) {
-      const nextSession = nextDay.find(this._getDateBeforeSessionFinder(moment));
-      return nextSession.from;
+      return nextDay.find(this._getDateBeforeSessionFinder(moment)).from;
     }
 
     return undefined;

--- a/src/lib/removePastAlterations.js
+++ b/src/lib/removePastAlterations.js
@@ -1,8 +1,8 @@
 const Moment = require('moment');
 
-function removePastAlterations(alterations, moment, timeZone) {
+function removePastAlterations(alterations, moment) {
   if (alterations) {
-    const todayInKeyFormat = Moment.tz(moment, timeZone).format('YYYY-MM-DD');
+    const todayInKeyFormat = Moment(moment).format('YYYY-MM-DD');
     const presentAndFutureAlterations = {};
     const alterationsKeys = Object.keys(alterations);
 

--- a/src/lib/removePastAlterations.js
+++ b/src/lib/removePastAlterations.js
@@ -1,8 +1,6 @@
-const Moment = require('moment');
-
 function removePastAlterations(alterations, moment) {
   if (alterations) {
-    const todayInKeyFormat = Moment(moment).format('YYYY-MM-DD');
+    const todayInKeyFormat = moment.format('YYYY-MM-DD');
     const presentAndFutureAlterations = {};
     const alterationsKeys = Object.keys(alterations);
 

--- a/test/unit/lib/removePastAlterations.js
+++ b/test/unit/lib/removePastAlterations.js
@@ -4,7 +4,6 @@ const removePastAlterations = require('../../../src/lib/removePastAlterations');
 const testUtils = require('../../lib/utils');
 
 const expect = chai.expect;
-const timeZone = 'Europe/London';
 const now = moment();
 
 describe('Utils', () => {
@@ -16,7 +15,7 @@ describe('Utils', () => {
     it('should remove alterations in the past', () => {
       const alterationsPast = testUtils.alterationsPast(now);
 
-      const strippedAlterations = removePastAlterations(alterationsPast, now, timeZone);
+      const strippedAlterations = removePastAlterations(alterationsPast, now);
 
       // eslint-disable-next-line no-unused-expressions
       expect(strippedAlterations).to.be.empty;
@@ -25,7 +24,7 @@ describe('Utils', () => {
     it('should not remove alterations in the future', () => {
       const alterationsFuture = testUtils.alterationsFuture(now);
 
-      const strippedAlterations = removePastAlterations(alterationsFuture, now, timeZone);
+      const strippedAlterations = removePastAlterations(alterationsFuture, now);
 
       expect(strippedAlterations).to.be.eql(alterationsFuture);
     });
@@ -33,7 +32,7 @@ describe('Utils', () => {
     it('should not remove alterations for present', () => {
       const alterationsPresent = testUtils.alterationsPresent(now);
 
-      const strippedAlterations = removePastAlterations(alterationsPresent, now, timeZone);
+      const strippedAlterations = removePastAlterations(alterationsPresent, now);
 
       expect(strippedAlterations).to.be.eql(alterationsPresent);
     });
@@ -43,7 +42,7 @@ describe('Utils', () => {
       const alterationsPresentAndFuture = testUtils.alterationsPresentAndFuture(now);
 
       const strippedAlterations =
-        removePastAlterations(alterationsPastPresentAndFuture, now, timeZone);
+        removePastAlterations(alterationsPastPresentAndFuture, now);
 
       expect(strippedAlterations).to.be.eql(alterationsPresentAndFuture);
     });


### PR DESCRIPTION
The timings of the performance unit test have dropped for both tests, with and without alterations. Without alterations the improvement is small - in the region of 50ms. With alterations, the improvement is larger, around 200ms. Going from ~750ms to ~700ms and from ~800ms to ~600ms, respectively, at least running them locally.