### PR TITLE
use grace period to consider a place open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+2.6.0 / 2017-11-01
+==================
+- Add grace period to consider a place open if opening in a few minutes.
+
 2.5.1 / 2017-11-01
 ==================
 - Remove prepublish script

--- a/OpeningTimes.js
+++ b/OpeningTimes.js
@@ -7,7 +7,8 @@ require('moment-timezone');
 const weekdays = require('moment').weekdays().map(d => d.toLowerCase());
 
 class OpeningTimes {
-  constructor(openingTimes, timeZone, alterations) {
+  constructor(openingTimes, timeZone, alterations, gracePeriodMins = 0) {
+    this._gracePeriodMins = gracePeriodMins;
     assert(openingTimes, 'parameter \'openingTimes\' undefined/empty');
     const parameterWeek = Object.keys(openingTimes).sort();
     assert.deepEqual(
@@ -25,6 +26,7 @@ class OpeningTimes {
     this._openingTimes = openingTimes;
     this._timeZone = timeZone;
     this._alterations = alterations;
+    this._gracePeriodMins = gracePeriodMins;
   }
 
   /* Private methods - you could use them but they  are not part of the API
@@ -88,7 +90,8 @@ class OpeningTimes {
 
       for (let j = 0; j < openingTimes.length; j += 1) {
         const t = openingTimes[j];
-        const from = this._createDateTime(aMoment, t.opens);
+        // consider grace period minutes befor opening time open
+        const from = this._createDateTime(aMoment, t.opens).subtract(this._gracePeriodMins, 'minutes');
         const to = this._createDateTime(aMoment, t.closes);
 
         if (to < from) {

--- a/README.md
+++ b/README.md
@@ -28,9 +28,13 @@ All peerDependencies need to be installed.
 
 ## Usage
 
-The class is instantiated with 3 arguments. The third argument is optional and
-represents a set of opening times classified as alterations. Once instantiated
-the function `getStatus` is passed the current time and an optional options object.
+The class is instantiated with 4 arguments.
+The third argument represents a set of opening times classified as alterations. 
+The fourth argument is optional and represents a grace period before a place's opening time when
+it is considered open, i.e. if the grace period is 1 minute, a place will be reported as open at
+8:59 if it opens at 9am.
+
+Once instantiated the function `getStatus` is passed the current time and an optional options object.
 Currently the only valid option is a boolean field - `next`. When
 `next` set to a truthy value the returned object will contain 2 additional
 fields, `nextClosed` and `nextOpen`. Both fields are a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moment-opening-times",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "A small class to determine the status of a given moment in relation to a set of opening times",
   "repository": {
     "type": "git",

--- a/test/unit/OpeningTimes.js
+++ b/test/unit/OpeningTimes.js
@@ -7,6 +7,7 @@ require('moment-timezone');
 
 const expect = chai.expect;
 const aSunday = Moment('2016-07-24T00:00:00+00:00');
+const gracePeriodMinutes = 1;
 
 chai.use(chaiMoment);
 chaiMoment.setErrorFormat('LLLL');
@@ -79,7 +80,7 @@ function momentsShouldBeSame(moment1, moment2) {
 }
 
 function getNewOpeningTimes(openingTimes, timeZone, alterations) {
-  return new OpeningTimes(openingTimes, timeZone, alterations);
+  return new OpeningTimes(openingTimes, timeZone, alterations, gracePeriodMinutes);
 }
 
 describe('OpeningTimes', () => {
@@ -193,8 +194,8 @@ describe('OpeningTimes', () => {
         });
       });
 
-      describe('moment 1 minute before session start', () => {
-        const moment = getMoment('monday', 8, 59, 'Europe/London');
+      describe('moment more that grace period minutes before session start should be closed', () => {
+        const moment = getMoment('monday', 8, 58, 'Europe/London');
         const status = openingTimes.getStatus(moment, { next: true });
         it('isOpen should be false', () => {
           expect(status.isOpen).to.equal(false);
@@ -204,6 +205,20 @@ describe('OpeningTimes', () => {
         });
         it('nextClosed should be passed moment', () => {
           momentsShouldBeSame(status.nextClosed, moment);
+        });
+      });
+
+      describe('moment less than grace period minutes before session start should be open', () => {
+        const moment = getMoment('monday', 8, 59, 'Europe/London');
+        const status = openingTimes.getStatus(moment, { next: true });
+        it('isOpen should be true', () => {
+          expect(status.isOpen).to.equal(true);
+        });
+        it('nextOpen should be passed moment', () => {
+          momentsShouldBeSame(status.nextOpen, moment);
+        });
+        it('nextClosed should be next closed', () => {
+          momentsShouldBeSame(status.nextClosed, getMoment('monday', 17, 30, 'Europe/London'));
         });
       });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2663,9 +2663,9 @@ snyk-mvn-plugin@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/snyk-mvn-plugin/-/snyk-mvn-plugin-1.1.0.tgz#6ad3fb670cd22972094f065ab99b90d286c8ad6f"
 
-snyk-nuget-plugin@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/snyk-nuget-plugin/-/snyk-nuget-plugin-1.0.0.tgz#2a0c132f1dbbf6ad7895b177ec2371d67b95160f"
+snyk-nuget-plugin@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/snyk-nuget-plugin/-/snyk-nuget-plugin-1.1.1.tgz#f23534ae9376075627321d3ecada50733e77918b"
   dependencies:
     es6-promise "^4.1.1"
     xml2js "^0.4.17"
@@ -2742,8 +2742,8 @@ snyk-try-require@^1.1.1, snyk-try-require@^1.2.0:
     then-fs "^2.0.0"
 
 snyk@^1.0.0:
-  version "1.47.0"
-  resolved "https://registry.yarnpkg.com/snyk/-/snyk-1.47.0.tgz#2c86a734a842fdfc18b97df682a91d419fec70f3"
+  version "1.49.1"
+  resolved "https://registry.yarnpkg.com/snyk/-/snyk-1.49.1.tgz#1bed0aace409b831e719516669c6b3d497171966"
   dependencies:
     abbrev "^1.0.7"
     ansi-escapes "^1.3.0"
@@ -2762,7 +2762,7 @@ snyk@^1.0.0:
     snyk-gradle-plugin "1.2.0"
     snyk-module "1.8.1"
     snyk-mvn-plugin "1.1.0"
-    snyk-nuget-plugin "1.0.0"
+    snyk-nuget-plugin "1.1.1"
     snyk-policy "1.7.1"
     snyk-python-plugin "1.4.0"
     snyk-recursive-readdir "^2.0.0"


### PR DESCRIPTION
Add grace period to consider a place open a number of minutes before it is really open, i.e. if the grace period is 2 minutes, and the premise opens at 9am it will be considered open at 8:58am.