### PR TITLE
Only require moment-timezone

### DIFF
--- a/OpeningTimes.js
+++ b/OpeningTimes.js
@@ -1,8 +1,7 @@
 const assert = require('assert');
 const util = require('util');
-const Moment = require('moment');
+const Moment = require('moment-timezone');
 const removePastAlterations = require('./src/lib/removePastAlterations');
-require('moment-timezone');
 
 const weekdays = require('moment').weekdays().map(d => d.toLowerCase());
 


### PR DESCRIPTION
Should only require `moment-timezone`, `moment` is a dependency of `moment-timezone`. 
See: https://github.com/moment/moment-timezone/blob/9b6555c5e884430c8d39d8b0112bedf4a8ccfda4/package.json#L30